### PR TITLE
✨ #66586 Migrate file dialog controller and part of dialog wrapper.

### DIFF
--- a/packages/file_selector/file_selector_windows/lib/src/file_selector_dart/file_dialog_controller.dart
+++ b/packages/file_selector/file_selector_windows/lib/src/file_selector_dart/file_dialog_controller.dart
@@ -1,0 +1,91 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ffi';
+
+import 'package:win32/win32.dart';
+
+import 'ifile_open_dialog_factory.dart';
+
+/// A thin wrapper for IFileDialog to allow for faking and inspection in tests.
+///
+/// Since this class defines the end of what can be unit tested, it should
+/// contain as little logic as possible.
+class FileDialogController {
+  /// Creates a controller managing [IFileDialog](https://pub.dev/documentation/win32/latest/winrt/IFileDialog-class.html).
+  /// It also receives an IFileOpenDialogFactory to construct [IFileOpenDialog]
+  /// instances.
+  FileDialogController(
+      IFileDialog fileDialog, IFileOpenDialogFactory iFileOpenDialogFactory)
+      : _fileDialog = fileDialog,
+        _iFileOpenDialogFactory = iFileOpenDialogFactory;
+
+  /// The [IFileDialog] to work with.
+  final IFileDialog _fileDialog;
+
+  /// The [IFileOpenDialogFactory] to work construc [IFileOpenDialog] instances.
+  final IFileOpenDialogFactory _iFileOpenDialogFactory;
+
+  /// Sets the default folder for the dialog to [path]. It also returns the operation result.
+  int setFolder(Pointer<COMObject> path) {
+    return _fileDialog.setFolder(path);
+  }
+
+  /// Sets the file [name] that is initially shown in the IFileDialog. It also returns the operation result.
+  int setFileName(String name) {
+    return _fileDialog.setFileName(TEXT(name));
+  }
+
+  /// Sets the allowed file type extensions in the IFileOpenDialog. It also returns the operation result.
+  int setFileTypes(int count, Pointer<COMDLG_FILTERSPEC> filters) {
+    return _fileDialog.setFileTypes(count, filters);
+  }
+
+  /// Sets the label of the confirmation button. It also returns the operation result. It also returns the operation result.
+  int setOkButtonLabel(String text) {
+    return _fileDialog.setOkButtonLabel(TEXT(text));
+  }
+
+  /// Gets the IFileDialog's [options](https://pub.dev/documentation/win32/latest/winrt/FILEOPENDIALOGOPTIONS-class.html),
+  /// which is a bitfield. It also returns the operation result.
+  int getOptions(Pointer<Uint32> outOptions) {
+    return _fileDialog.getOptions(outOptions);
+  }
+
+  /// Sets the [options](https://pub.dev/documentation/win32/latest/winrt/FILEOPENDIALOGOPTIONS-class.html),
+  /// which is a bitfield, into the IFileDialog. It also returns the operation result.
+  int setOptions(int options) {
+    return _fileDialog.setOptions(options);
+  }
+
+  /// Shows an IFileDialog using the given parent. It returns the operation result.
+  int show(int parent) {
+    return _fileDialog.show(parent);
+  }
+
+  /// Return results from an IFileDialog. This should be used when selecting
+  /// single items. It also returns the operation result.
+  int getResult(Pointer<Pointer<COMObject>> outItem) {
+    return _fileDialog.getResult(outItem);
+  }
+
+  /// Return results from an IFileOpenDialog. This should be used when selecting
+  /// single items. This function will fail if the IFileDialog* provided to the
+  /// constructor was not an IFileOpenDialog instance, returning an E_FAIL
+  /// error.
+  int getResults(Pointer<Pointer<COMObject>> outItems) {
+    IFileOpenDialog? fileOpenDialog;
+    try {
+      fileOpenDialog = _iFileOpenDialogFactory.from(_fileDialog);
+      return fileOpenDialog.getResults(outItems);
+    } catch (_) {
+      return E_FAIL;
+    } finally {
+      fileOpenDialog?.release();
+      if (fileOpenDialog != null) {
+        free(fileOpenDialog.ptr);
+      }
+    }
+  }
+}

--- a/packages/file_selector/file_selector_windows/lib/src/file_selector_dart/ifile_open_dialog_factory.dart
+++ b/packages/file_selector/file_selector_windows/lib/src/file_selector_dart/ifile_open_dialog_factory.dart
@@ -1,0 +1,13 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:win32/win32.dart';
+
+/// A wrapper of the IFileOpenDialog interface to use its from function.
+class IFileOpenDialogFactory {
+  /// Wraps the IFileOpenDialog from function.
+  IFileOpenDialog from(IFileDialog fileDialog) {
+    return IFileOpenDialog.from(fileDialog);
+  }
+}

--- a/packages/file_selector/file_selector_windows/pubspec.yaml
+++ b/packages/file_selector/file_selector_windows/pubspec.yaml
@@ -18,9 +18,11 @@ flutter:
 
 dependencies:
   cross_file: ^0.3.1
+  ffi: ^2.0.1
   file_selector_platform_interface: ^2.1.0
   flutter:
     sdk: flutter
+  win32: ^3.0.0
 
 dev_dependencies:
   build_runner: 2.1.11

--- a/packages/file_selector/file_selector_windows/test/file_selector_dart/fake_file_dialog.dart
+++ b/packages/file_selector/file_selector_windows/test/file_selector_dart/fake_file_dialog.dart
@@ -1,0 +1,112 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ffi';
+
+import 'package:ffi/ffi.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:win32/win32.dart';
+
+// Fake IFileDialog class for testing purposes.
+class FakeIFileDialog extends Fake implements IFileDialog {
+  int _getOptionsCalledTimes = 0;
+  int _getResultCalledTimes = 0;
+  int _setOptionsCalledTimes = 0;
+  int _setFolderCalledTimes = 0;
+  int _setFileNameCalledTimes = 0;
+  int _setFileTypesCalledTimes = 0;
+  int _setOkButtonLabelCalledTimes = 0;
+  int _showCalledTimes = 0;
+
+  @override
+  int getOptions(Pointer<Uint32> pfos) {
+    _getOptionsCalledTimes++;
+    return S_OK;
+  }
+
+  @override
+  int setOptions(int options) {
+    _setOptionsCalledTimes++;
+    return S_OK;
+  }
+
+  @override
+  int getResult(Pointer<Pointer<COMObject>> ppsi) {
+    _getResultCalledTimes++;
+    return S_OK;
+  }
+
+  @override
+  int setFolder(Pointer<COMObject> psi) {
+    _setFolderCalledTimes++;
+    return S_OK;
+  }
+
+  @override
+  int setFileTypes(int cFileTypes, Pointer<COMDLG_FILTERSPEC> rgFilterSpec) {
+    _setFileTypesCalledTimes++;
+    return S_OK;
+  }
+
+  @override
+  int setFileName(Pointer<Utf16> pszName) {
+    _setFileNameCalledTimes++;
+    return S_OK;
+  }
+
+  @override
+  int setOkButtonLabel(Pointer<Utf16> pszText) {
+    _setOkButtonLabelCalledTimes++;
+    return S_OK;
+  }
+
+  @override
+  int show(int hwndOwner) {
+    _showCalledTimes++;
+    return S_OK;
+  }
+
+  void resetCounters() {
+    _getOptionsCalledTimes = 0;
+    _getResultCalledTimes = 0;
+    _setOptionsCalledTimes = 0;
+    _setFolderCalledTimes = 0;
+    _setFileTypesCalledTimes = 0;
+    _setOkButtonLabelCalledTimes = 0;
+    _showCalledTimes = 0;
+    _setFileNameCalledTimes = 0;
+  }
+
+  int getOptionsCalledTimes() {
+    return _getOptionsCalledTimes;
+  }
+
+  int setOptionsCalledTimes() {
+    return _setOptionsCalledTimes;
+  }
+
+  int getResultCalledTimes() {
+    return _getResultCalledTimes;
+  }
+
+  int setFolderCalledTimes() {
+    return _setFolderCalledTimes;
+  }
+
+  int setFileNameCalledTimes() {
+    return _setFileNameCalledTimes;
+  }
+
+  int setFileTypesCalledTimes() {
+    return _setFileTypesCalledTimes;
+  }
+
+  int setOkButtonLabelCalledTimes() {
+    return _setOkButtonLabelCalledTimes;
+  }
+
+  int showCalledTimes() {
+    return _showCalledTimes;
+  }
+}

--- a/packages/file_selector/file_selector_windows/test/file_selector_dart/fake_ifile_open_dialog.dart
+++ b/packages/file_selector/file_selector_windows/test/file_selector_dart/fake_ifile_open_dialog.dart
@@ -1,0 +1,55 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ffi';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:win32/win32.dart';
+
+// Fake IFileOpenDialog class for testing purposes.
+class FakeIFileOpenDialog extends Fake implements IFileOpenDialog {
+  int _getResultsCalledTimes = 0;
+  int _getReleaseCalledTimes = 0;
+  bool _shouldFail = false;
+
+  @override
+  Pointer<COMObject> get ptr => nullptr;
+
+  @override
+  int release() {
+    _getReleaseCalledTimes++;
+    return S_OK;
+  }
+
+  @override
+  int getResults(Pointer<Pointer<COMObject>> ppsi) {
+    _getResultsCalledTimes++;
+    if (_shouldFail) {
+      throw WindowsException(E_FAIL);
+    }
+
+    return S_OK;
+  }
+
+  void resetCounters() {
+    _getResultsCalledTimes = 0;
+    _getReleaseCalledTimes = 0;
+  }
+
+  int getResultsCalledTimes() {
+    return _getResultsCalledTimes;
+  }
+
+  int getReleaseCalledTimes() {
+    return _getReleaseCalledTimes;
+  }
+
+  void mockFailure() {
+    _shouldFail = true;
+  }
+
+  void mockSuccess() {
+    _shouldFail = false;
+  }
+}

--- a/packages/file_selector/file_selector_windows/test/file_selector_dart/fake_ifile_open_dialog_factory.dart
+++ b/packages/file_selector/file_selector_windows/test/file_selector_dart/fake_ifile_open_dialog_factory.dart
@@ -1,0 +1,40 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file_selector_windows/src/file_selector_dart/ifile_open_dialog_factory.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:win32/win32.dart';
+
+import 'fake_ifile_open_dialog.dart';
+
+// Fake FakeIFileOpenDialogFactory class for testing purposes.
+class FakeIFileOpenDialogFactory extends Fake
+    implements IFileOpenDialogFactory {
+  int _fromCalledTimes = 0;
+  bool _shouldFail = false;
+
+  final FakeIFileOpenDialog fakeIFileOpenDialog = FakeIFileOpenDialog();
+
+  @override
+  IFileOpenDialog from(IFileDialog dialog) {
+    _fromCalledTimes++;
+    if (_shouldFail) {
+      throw WindowsException(E_NOINTERFACE);
+    }
+
+    return fakeIFileOpenDialog;
+  }
+
+  int getFromCalledTimes() {
+    return _fromCalledTimes;
+  }
+
+  void mockSuccess() {
+    _shouldFail = false;
+  }
+
+  void mockFailure() {
+    _shouldFail = true;
+  }
+}

--- a/packages/file_selector/file_selector_windows/test/file_selector_dart/file_dialog_controller_test.dart
+++ b/packages/file_selector/file_selector_windows/test/file_selector_dart/file_dialog_controller_test.dart
@@ -1,0 +1,131 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ffi';
+
+import 'package:ffi/ffi.dart';
+import 'package:file_selector_windows/src/file_selector_dart/file_dialog_controller.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:win32/win32.dart';
+
+import 'fake_file_dialog.dart';
+import 'fake_ifile_open_dialog_factory.dart';
+
+void main() {
+  final FakeIFileDialog fakeFileOpenDialog = FakeIFileDialog();
+  final FakeIFileOpenDialogFactory fakeIFileOpenDialogFactory =
+      FakeIFileOpenDialogFactory();
+  final FileDialogController fileDialogController =
+      FileDialogController(fakeFileOpenDialog, fakeIFileOpenDialogFactory);
+
+  setUp(() {
+    fakeIFileOpenDialogFactory.mockSuccess();
+    fakeIFileOpenDialogFactory.fakeIFileOpenDialog.mockSuccess();
+  });
+
+  tearDown(() {
+    fakeFileOpenDialog.resetCounters();
+    fakeIFileOpenDialogFactory.fakeIFileOpenDialog.resetCounters();
+  });
+
+  test('setFolder should call dialog setFolder', () {
+    final Pointer<COMObject> ptrFolder = calloc<COMObject>();
+    fileDialogController.setFolder(ptrFolder);
+    free(ptrFolder);
+    expect(fakeFileOpenDialog.setFolderCalledTimes(), 1);
+  });
+
+  test('setFileName should call dialog setFileName', () {
+    fileDialogController.setFileName('fileName');
+    expect(fakeFileOpenDialog.setFileNameCalledTimes(), 1);
+  });
+
+  test('setFileTypes should call dialog setFileTypes', () {
+    final Pointer<COMDLG_FILTERSPEC> ptrFilters = calloc<COMDLG_FILTERSPEC>();
+    fileDialogController.setFileTypes(1, ptrFilters);
+    free(ptrFilters);
+    expect(fakeFileOpenDialog.setFileTypesCalledTimes(), 1);
+  });
+
+  test('setOkButtonLabel should call dialog setOkButtonLabel', () {
+    fileDialogController.setOkButtonLabel('button');
+    expect(fakeFileOpenDialog.setOkButtonLabelCalledTimes(), 1);
+  });
+
+  test('show should call dialog show', () {
+    fileDialogController.show(0);
+    expect(fakeFileOpenDialog.showCalledTimes(), 1);
+  });
+
+  test('getOptions should call dialog getOptions', () {
+    final Pointer<Uint32> ptrOptions = calloc<Uint32>();
+    fileDialogController.getOptions(ptrOptions);
+    expect(fakeFileOpenDialog.getOptionsCalledTimes(), 1);
+    free(ptrOptions);
+  });
+
+  test('setOptions should call dialog setOptions', () {
+    fileDialogController.setOptions(32);
+    expect(fakeFileOpenDialog.setOptionsCalledTimes(), 1);
+  });
+
+  test('getResult should call dialog getResult', () {
+    final Pointer<Pointer<COMObject>> ptrCOMObject =
+        calloc<Pointer<COMObject>>();
+    fileDialogController.getResult(ptrCOMObject);
+    expect(fakeFileOpenDialog.getResultCalledTimes(), 1);
+    free(ptrCOMObject);
+  });
+
+  test('getResults should call the from method of the factory', () {
+    final Pointer<Pointer<COMObject>> ptrCOMObject =
+        calloc<Pointer<COMObject>>();
+    fileDialogController.getResults(ptrCOMObject);
+    expect(fakeIFileOpenDialogFactory.getFromCalledTimes(), 1);
+    free(ptrCOMObject);
+  });
+
+  test('getResults should call dialog getResults', () {
+    final Pointer<Pointer<COMObject>> ptrCOMObject =
+        calloc<Pointer<COMObject>>();
+    fileDialogController.getResults(ptrCOMObject);
+    expect(
+        fakeIFileOpenDialogFactory.fakeIFileOpenDialog.getResultsCalledTimes(),
+        1);
+    free(ptrCOMObject);
+  });
+
+  test(
+      'getResults should return an error when building a file open dialog throws',
+      () {
+    final Pointer<Pointer<COMObject>> ptrCOMObject =
+        calloc<Pointer<COMObject>>();
+    fakeIFileOpenDialogFactory.mockFailure();
+    expect(fileDialogController.getResults(ptrCOMObject), E_FAIL);
+    free(ptrCOMObject);
+  });
+
+  test(
+      'getResults should return an error and release the dialog when getting results throws',
+      () {
+    final Pointer<Pointer<COMObject>> ptrCOMObject =
+        calloc<Pointer<COMObject>>();
+    fakeIFileOpenDialogFactory.fakeIFileOpenDialog.mockFailure();
+    expect(fileDialogController.getResults(ptrCOMObject), E_FAIL);
+    expect(
+        fakeIFileOpenDialogFactory.fakeIFileOpenDialog.getReleaseCalledTimes(),
+        1);
+    free(ptrCOMObject);
+  });
+
+  test('getResults should call dialog release', () {
+    final Pointer<Pointer<COMObject>> ptrCOMObject =
+        calloc<Pointer<COMObject>>();
+    fileDialogController.getResults(ptrCOMObject);
+    expect(
+        fakeIFileOpenDialogFactory.fakeIFileOpenDialog.getReleaseCalledTimes(),
+        1);
+    free(ptrCOMObject);
+  });
+}


### PR DESCRIPTION
We're setting the basis for the 1-on-1 migration from c++ to Dart. This PR is intended to collect feedback and validate our approach.

## Things we have done:
- Migrate the file_dialog_controller.cpp class to Dart using the win32 package.
- Add tests and fake classes where needed.

## Things that need validation:
- Changed some of the signatures:
   - Due to constraints of the [ffi Pointers](https://api.dart.dev/stable/2.18.0/dart-ffi/Pointer-class.html), we used COMObject pointers.
   - Instead of returning an _HRESULT_, this implementation returns `int`, cloning the signature of the methods exposed by the [API](https://pub.dev/documentation/win32/latest/winrt/IFileOpenDialog/getResults.html).
- The [GetResults method](https://github.com/flutter/plugins/blob/main/packages/file_selector/file_selector_windows/windows/file_dialog_controller.cpp#L54) uses [queryInterface](https://pub.dev/documentation/win32/latest/topics/com-topic.html), to migrate it to Dart this uses the Win32 package that offers a wrapper over it that allows us to retrieve a pointer to a different supported interface.
- There is no built-in clone method in Dart. In addition to this, as the default constructor has been rewritten, there is no way of passing a FileDialogController as an input parameter.

Issue:
[#112212 [file_selector_windows] Migrate CPP implementation to Dart.](https://github.com/flutter/flutter/issues/112212)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
