### PR TITLE
✨ #65840 Save a file

### DIFF
--- a/packages/file_selector/file_selector_android/android/build.gradle
+++ b/packages/file_selector/file_selector_android/android/build.gradle
@@ -43,6 +43,7 @@ android {
         testImplementation 'org.mockito:mockito-core:4.8.0'
         testImplementation 'androidx.test:core:1.4.0'
         testImplementation "org.robolectric:robolectric:4.8.1"
+        testImplementation "org.mockito:mockito-inline:2.7.21"
     }
 
     testOptions {

--- a/packages/file_selector/file_selector_android/android/src/main/java/io/flutter/plugins/file_selector/FileSelectorDelegate.java
+++ b/packages/file_selector/file_selector_android/android/src/main/java/io/flutter/plugins/file_selector/FileSelectorDelegate.java
@@ -8,7 +8,6 @@ import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
@@ -39,13 +38,13 @@ public class FileSelectorDelegate
     implements PluginRegistry.ActivityResultListener,
         PluginRegistry.RequestPermissionsResultListener {
   @VisibleForTesting static final int REQUEST_CODE_GET_DIRECTORY_PATH = 2342;
-  @VisibleForTesting static final int REQUEST_CODE_GET_SAVE_PATH = 2343;
+  @VisibleForTesting static final int REQUEST_CODE_GET_SAVE_PATH = 2344;
 
   /** Constants for key types in the dart invoke methods */
   @VisibleForTesting static final String _confirmButtonText = "confirmButtonText";
 
   @VisibleForTesting static final String _initialDirectory = "initialDirectory";
-  @VisibleForTesting static final  String _suggestedNameKey = "suggestedName";
+  @VisibleForTesting static final String _suggestedNameKey = "suggestedName";
 
   private final Activity activity;
 
@@ -110,7 +109,8 @@ public class FileSelectorDelegate
     activity.startActivityForResult(getDirectoryPathIntent, REQUEST_CODE_GET_DIRECTORY_PATH);
   }
 
-  private void launchGetSavePath(@Nullable String initialDirectory, @Nullable String suggestedName) {
+  private void launchGetSavePath(
+      @Nullable String initialDirectory, @Nullable String suggestedName) {
     Intent getSavePathIntent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
     getSavePathIntent.setType("*/*");
 
@@ -158,7 +158,7 @@ public class FileSelectorDelegate
   private void handleGetSavePathResult(int resultCode, Intent data) {
     if (resultCode == Activity.RESULT_OK && data != null) {
       Uri path = data.getData();
-      String fullPath = PathUtils.getPath(path, this.activity);
+      String fullPath = PathUtils.getSavePathUri(path, this.activity);
       handleGetSavePathResult(fullPath);
       return;
     }
@@ -169,6 +169,7 @@ public class FileSelectorDelegate
   private void handleGetDirectoryPathResult(String path) {
     finishWithSuccess(path);
   }
+
   private void handleGetSavePathResult(String path) {
     finishWithSuccess(path);
   }

--- a/packages/file_selector/file_selector_android/android/src/main/java/io/flutter/plugins/file_selector/FileSelectorPlugin.java
+++ b/packages/file_selector/file_selector_android/android/src/main/java/io/flutter/plugins/file_selector/FileSelectorPlugin.java
@@ -112,7 +112,8 @@ public class FileSelectorPlugin
         delegate.getDirectoryPath(call, result);
         break;
       case METHOD_GET_SAVE_PATH:
-        throw new UnsupportedOperationException("getSavePath is not supported yet");
+        delegate.getSavePath(call, result);
+        break;
       case METHOD_OPEN_FILE:
         throw new UnsupportedOperationException("openFile is not supported yet");
       default:

--- a/packages/file_selector/file_selector_android/android/src/main/java/io/flutter/plugins/file_selector/PathUtils.java
+++ b/packages/file_selector/file_selector_android/android/src/main/java/io/flutter/plugins/file_selector/PathUtils.java
@@ -23,6 +23,8 @@ public class PathUtils {
   static final String providersDownloadsDocuments = "com.android.providers.downloads.documents";
   static final String providersMediaDocuments = "com.android.providers.media.documents";
 
+  /** Given a projection, returns the file name for the uri
+   using the content resolver to avoid unwanted parsing. */
   public static String getFileName(Uri uri, @NonNull Context context, String[] projection) {
     Cursor returnCursor = context.getContentResolver().query(uri, projection, null, null, null);
 
@@ -72,6 +74,13 @@ public class PathUtils {
     return output.getAbsolutePath();
   }
 
+  /**
+  * Returns an absolute path for the file to be saved from
+  * the 3 possible content paths to return.
+  * If none of these match, then we will create a copy
+  * of the created file in the internal storage and
+  * return that path.
+  */
   @VisibleForTesting
   @Nullable
   public static String getSavePathUri(final Uri uri, Context context) {

--- a/packages/file_selector/file_selector_android/android/src/main/java/io/flutter/plugins/file_selector/PathUtils.java
+++ b/packages/file_selector/file_selector_android/android/src/main/java/io/flutter/plugins/file_selector/PathUtils.java
@@ -1,0 +1,240 @@
+package io.flutter.plugins.file_selector;
+
+import android.content.ContentUris;
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Environment;
+import android.provider.DocumentsContract;
+import android.provider.MediaStore;
+import android.provider.OpenableColumns;
+import android.text.TextUtils;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+
+public class PathUtils {
+    private static Uri contentUri = null;
+
+    @Nullable
+    public static String getPath(final Uri uri, Context context) {
+        String selection;
+        String[] selectionArgs;
+        final String docId = DocumentsContract.getDocumentId(uri);
+
+        if (isExternalStorageDocument(uri)) {
+            final String[] split = docId.split(":");
+
+            String fullPath = getPathFromExtSD(split);
+            if (!fullPath.isEmpty()) {
+                return fullPath;
+            } else {
+                return null;
+            }
+        }
+
+        if (isDownloadsDocument(uri)) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                try (Cursor cursor = context.getContentResolver().query(uri, new String[]{MediaStore.MediaColumns.DISPLAY_NAME}, null, null, null)) {
+                    if (cursor != null && cursor.moveToFirst()) {
+                        String fileName = cursor.getString(0);
+                        String path = Environment.getExternalStorageDirectory().toString() + "/Download/" + fileName;
+                        if (!TextUtils.isEmpty(path)) {
+                            return path;
+                        }
+                    }
+                }
+                if (!TextUtils.isEmpty(docId)) {
+                    if (docId.startsWith("raw:")) {
+                        return docId.replaceFirst("raw:", "");
+                    }
+                    String[] contentUriPrefixesToTry = new String[]{
+                            "content://downloads/public_downloads",
+                            "content://downloads/my_downloads"
+                    };
+                    for (String contentUriPrefix : contentUriPrefixesToTry) {
+                        try {
+                            final Uri contentUri = ContentUris.withAppendedId(Uri.parse(contentUriPrefix), Long.parseLong(docId));
+
+                            return getDataColumn(context, contentUri, null, null);
+                        } catch (NumberFormatException e) {
+                            //In Android 8 and Android P the id is not a number
+                            return uri.getPath().replaceFirst("^/document/raw:", "").replaceFirst("^raw:", "");
+                        }
+                    }
+
+
+                }
+            }
+            else {
+                final String id = DocumentsContract.getDocumentId(uri);
+
+                if (id.startsWith("raw:")) {
+                    return id.replaceFirst("raw:", "");
+                }
+
+                try {
+                    contentUri = ContentUris.withAppendedId(
+                            Uri.parse("content://downloads/public_downloads"), Long.parseLong(id));
+                }
+                catch (NumberFormatException e) {
+                    e.printStackTrace();
+                }
+                if (contentUri != null) {
+                    return getDataColumn(context, contentUri, null, null);
+                }
+            }
+        }
+
+        // MediaProvider
+        if (isMediaDocument(uri)) {
+            final String[] split = docId.split(":");
+            final String type = split[0];
+
+            Uri contentUri = null;
+
+            switch (type) {
+                case "image":
+                    contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
+                    break;
+                case "video":
+                    contentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
+                    break;
+                case "audio":
+                    contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
+                    break;
+            }
+            selection = "_id=?";
+            selectionArgs = new String[]{split[1]};
+
+            return getDataColumn(context, contentUri, selection,
+                    selectionArgs);
+        }
+
+        if ("content".equalsIgnoreCase(uri.getScheme())) {
+            if( Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
+            {
+                return copyFileToInternalStorage(uri,context);
+            }
+            else
+            {
+                return getDataColumn(context, uri, null, null);
+            }
+        }
+        if ("file".equalsIgnoreCase(uri.getScheme())) {
+            return uri.getPath();
+        }
+
+        return null;
+    }
+
+    private static boolean fileExists(String filePath) {
+        File file = new File(filePath);
+
+        return file.exists();
+    }
+
+    @NonNull
+    private static String getPathFromExtSD(@NonNull String[] pathData) {
+        final String type = pathData[0];
+        final String relativePath = "/" + pathData[1];
+        String fullPath;
+
+        if ("primary".equalsIgnoreCase(type)) {
+            fullPath = Environment.getExternalStorageDirectory() + relativePath;
+            if (fileExists(fullPath)) {
+                return fullPath;
+            }
+        }
+
+        // Environment.isExternalStorageRemovable() is `true` for external and internal storage
+        // so we cannot relay on it.
+        //
+        // instead, for each possible path, check if file exists
+        // we'll start with secondary storage as this could be our (physically) removable sd card
+        fullPath = System.getenv("SECONDARY_STORAGE") + relativePath;
+        if (fileExists(fullPath)) {
+            return fullPath;
+        }
+
+        fullPath = System.getenv("EXTERNAL_STORAGE") + relativePath;
+        fileExists(fullPath);
+
+        return fullPath;
+    }
+
+    @NonNull
+    private static String copyFileToInternalStorage(Uri uri, @NonNull Context context) {
+        Cursor returnCursor = context.getContentResolver().query(uri, new String[]{
+                OpenableColumns.DISPLAY_NAME,OpenableColumns.SIZE
+        }, null, null, null);
+
+        int nameIndex = returnCursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
+        returnCursor.moveToFirst();
+        String name = (returnCursor.getString(nameIndex));
+
+        File output;
+        output = new File(context.getFilesDir() + "/" + name);
+
+        try {
+            InputStream inputStream = context.getContentResolver().openInputStream(uri);
+            FileOutputStream outputStream = new FileOutputStream(output);
+            int read;
+            int bufferSize = 1024;
+            final byte[] buffers = new byte[bufferSize];
+            while ((read = inputStream.read(buffers)) != -1) {
+                outputStream.write(buffers, 0, read);
+            }
+
+            inputStream.close();
+            outputStream.close();
+            returnCursor.close();
+        }
+        catch (Exception e) {
+            Log.e("Exception", e.getMessage());
+        }
+
+        return output.getPath();
+    }
+
+    @Nullable
+    private static String getDataColumn(@NonNull Context context, Uri uri, String selection, String[] selectionArgs) {
+        Cursor cursor = null;
+        final String column = "_data";
+        final String[] projection = {column};
+
+        try {
+            cursor = context.getContentResolver().query(uri, projection,
+                    selection, selectionArgs, null);
+
+            if (cursor != null && cursor.moveToFirst()) {
+                final int index = cursor.getColumnIndexOrThrow(column);
+                return cursor.getString(index);
+            }
+        }
+        finally {
+            if (cursor != null)
+                cursor.close();
+        }
+
+        return null;
+    }
+
+    private static boolean isExternalStorageDocument(@NonNull Uri uri) {
+        return "com.android.externalstorage.documents".equals(uri.getAuthority());
+    }
+
+    private static boolean isDownloadsDocument(@NonNull Uri uri) {
+        return "com.android.providers.downloads.documents".equals(uri.getAuthority());
+    }
+
+    private static boolean isMediaDocument(@NonNull Uri uri) {
+        return "com.android.providers.media.documents".equals(uri.getAuthority());
+    }
+}

--- a/packages/file_selector/file_selector_android/android/src/test/java/io/flutter/plugins/file_selector/FileSelectorDelegateTest.java
+++ b/packages/file_selector/file_selector_android/android/src/test/java/io/flutter/plugins/file_selector/FileSelectorDelegateTest.java
@@ -5,6 +5,7 @@
 package io.flutter.plugins.file_selector;
 
 import static io.flutter.plugins.file_selector.FileSelectorPlugin.METHOD_GET_DIRECTORY_PATH;
+import static io.flutter.plugins.file_selector.FileSelectorPlugin.METHOD_GET_SAVE_PATH;
 import static io.flutter.plugins.file_selector.TestHelpers.buildMethodCall;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -42,6 +43,17 @@ public class FileSelectorDelegateTest {
     FileSelectorDelegate delegate = new FileSelectorDelegate(mockActivity, mockResult, call);
 
     delegate.getDirectoryPath(call, mockResult);
+
+    verifyFinishedWithAlreadyActiveError();
+    verifyNoMoreInteractions(mockResult);
+  }
+
+  @Test
+  public void getSavePath_WhenPendingResultExists_FinishesWithAlreadyActiveError() {
+    MethodCall call = buildMethodCall(METHOD_GET_SAVE_PATH);
+    FileSelectorDelegate delegate = new FileSelectorDelegate(mockActivity, mockResult, call);
+
+    delegate.getSavePath(call, mockResult);
 
     verifyFinishedWithAlreadyActiveError();
     verifyNoMoreInteractions(mockResult);

--- a/packages/file_selector/file_selector_android/android/src/test/java/io/flutter/plugins/file_selector/FileSelectorDelegateTest.java
+++ b/packages/file_selector/file_selector_android/android/src/test/java/io/flutter/plugins/file_selector/FileSelectorDelegateTest.java
@@ -7,7 +7,10 @@ package io.flutter.plugins.file_selector;
 import static io.flutter.plugins.file_selector.FileSelectorPlugin.METHOD_GET_DIRECTORY_PATH;
 import static io.flutter.plugins.file_selector.FileSelectorPlugin.METHOD_GET_SAVE_PATH;
 import static io.flutter.plugins.file_selector.TestHelpers.buildMethodCall;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -17,10 +20,14 @@ import android.content.Intent;
 import android.net.Uri;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
 
 public class FileSelectorDelegateTest {
   @Mock Activity mockActivity;
@@ -29,12 +36,27 @@ public class FileSelectorDelegateTest {
 
   @Mock Uri mockUri;
 
+  @Mock PathUtils mockPathUtils;
+  @Spy FileSelectorDelegate spyFileSelectorDelegate;
+
   @Before
   public void setUp() {
     MockitoAnnotations.openMocks(this);
 
-    mockUri = mock(Uri.class);
+    //    spyFileSelectorDelegate.cacheFolder = fakeFolder;
+
+    spyFileSelectorDelegate = spy(new FileSelectorDelegate(mockActivity));
     when(mockIntent.getData()).thenReturn(mockUri);
+  }
+
+  @After
+  public void tearDown() {
+    reset(mockUri);
+    reset(mockActivity);
+    reset(mockIntent);
+    reset(mockPathUtils);
+    reset(mockResult);
+    reset(spyFileSelectorDelegate);
   }
 
   @Test
@@ -83,8 +105,64 @@ public class FileSelectorDelegateTest {
     verifyNoMoreInteractions(mockResult);
   }
 
-  private FileSelectorDelegate createDelegate() {
-    return new FileSelectorDelegate(mockActivity, null, null);
+  public void getSavePath_WhenItIsCalled_launchGetDirectoryPath_NullArguments() {
+    MethodCall call = buildMethodCall(METHOD_GET_SAVE_PATH, null, null, null);
+    spyFileSelectorDelegate = spy(new FileSelectorDelegate(mockActivity));
+
+    doAnswer(
+            (invocation) -> {
+              return null;
+            })
+        .when(spyFileSelectorDelegate)
+        .launchGetSavePath(null, null);
+
+    spyFileSelectorDelegate.getSavePath(call, mockResult);
+
+    verify(spyFileSelectorDelegate).launchGetSavePath(null, null);
+  }
+
+  @Test
+  public void getSavePath_WhenItIsCalled_launchGetDirectoryPath_WithInitialDirAndSuggestedName() {
+    MethodCall call = buildMethodCall(METHOD_GET_SAVE_PATH, "testDir", null, "testName");
+    spyFileSelectorDelegate = spy(new FileSelectorDelegate(mockActivity));
+
+    doAnswer(
+            (invocation) -> {
+              return null;
+            })
+        .when(spyFileSelectorDelegate)
+        .launchGetSavePath("testDir", "testName");
+
+    spyFileSelectorDelegate.getSavePath(call, mockResult);
+
+    verify(spyFileSelectorDelegate).launchGetSavePath("testDir", "testName");
+  }
+
+  @Test
+  public void onActivityResult_WhenGetSavePath_InvokesHandleGetSavePathResult() {
+    doAnswer(
+            (invocation) -> {
+              return null;
+            })
+        .when(spyFileSelectorDelegate)
+        .handleGetSavePathResult(Activity.RESULT_OK, mockIntent);
+
+    spyFileSelectorDelegate.onActivityResult(
+        FileSelectorDelegate.REQUEST_CODE_GET_SAVE_PATH, Activity.RESULT_OK, mockIntent);
+
+    verify(spyFileSelectorDelegate).handleGetSavePathResult(Activity.RESULT_OK, mockIntent);
+  }
+
+  @Test
+  public void handleGetSavePathResult_WhenItIsCalled_InvokesGetSavePathUriFromPathUtils() {
+    MethodCall call = buildMethodCall(METHOD_GET_SAVE_PATH, null, null, null);
+    FileSelectorDelegate delegate = createDelegateWithPendingResultAndMethodCall(call);
+
+    try (MockedStatic<PathUtils> mockedPathUtils = Mockito.mockStatic(PathUtils.class)) {
+      delegate.handleGetSavePathResult(Activity.RESULT_OK, mockIntent);
+
+      mockedPathUtils.verify(() -> PathUtils.getSavePathUri(mockUri, mockActivity), times(1));
+    }
   }
 
   private FileSelectorDelegate createDelegateWithPendingResultAndMethodCall(MethodCall call) {

--- a/packages/file_selector/file_selector_android/android/src/test/java/io/flutter/plugins/file_selector/FileSelectorDelegateTest.java
+++ b/packages/file_selector/file_selector_android/android/src/test/java/io/flutter/plugins/file_selector/FileSelectorDelegateTest.java
@@ -43,8 +43,6 @@ public class FileSelectorDelegateTest {
   public void setUp() {
     MockitoAnnotations.openMocks(this);
 
-    //    spyFileSelectorDelegate.cacheFolder = fakeFolder;
-
     spyFileSelectorDelegate = spy(new FileSelectorDelegate(mockActivity));
     when(mockIntent.getData()).thenReturn(mockUri);
   }

--- a/packages/file_selector/file_selector_android/android/src/test/java/io/flutter/plugins/file_selector/FileSelectorPluginTest.java
+++ b/packages/file_selector/file_selector_android/android/src/test/java/io/flutter/plugins/file_selector/FileSelectorPluginTest.java
@@ -5,6 +5,7 @@
 package io.flutter.plugins.file_selector;
 
 import static io.flutter.plugins.file_selector.FileSelectorPlugin.METHOD_GET_DIRECTORY_PATH;
+import static io.flutter.plugins.file_selector.FileSelectorPlugin.METHOD_GET_SAVE_PATH;
 import static io.flutter.plugins.file_selector.TestHelpers.buildMethodCall;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -80,7 +81,7 @@ public class FileSelectorPluginTest {
   @Test
   public void
       onMethodCall_GetDirectoryPath_WhenCalledWithoutInitialDirectory_InvokesRootSourceFolder() {
-    MethodCall call = buildMethodCall(METHOD_GET_DIRECTORY_PATH, null, null);
+    MethodCall call = buildMethodCall(METHOD_GET_DIRECTORY_PATH, null, null, null);
     plugin.onMethodCall(call, mockResult);
     verify(mockFileSelectorDelegate).getDirectoryPath(eq(call), any());
     verifyNoInteractions(mockResult);
@@ -88,9 +89,26 @@ public class FileSelectorPluginTest {
 
   @Test
   public void onMethodCall_GetDirectoryPath_WhenCalledWithInitialDirectory_InvokesSourceFolder() {
-    MethodCall call = buildMethodCall(METHOD_GET_DIRECTORY_PATH, "Documents", null);
+    MethodCall call = buildMethodCall(METHOD_GET_DIRECTORY_PATH, "Documents", null, null);
     plugin.onMethodCall(call, mockResult);
     verify(mockFileSelectorDelegate).getDirectoryPath(eq(call), any());
+    verifyNoInteractions(mockResult);
+  }
+
+  @Test
+  public void
+  onMethodCall_GetSavePath_WhenCalledWithoutSuggestedName_InvokesSuccessfully() {
+    MethodCall call = buildMethodCall(METHOD_GET_SAVE_PATH, null, null, null);
+    plugin.onMethodCall(call, mockResult);
+    verify(mockFileSelectorDelegate).getSavePath(eq(call), any());
+    verifyNoInteractions(mockResult);
+  }
+
+  @Test
+  public void onMethodCall_GetSavePath_WhenCalledWithSuggestedName_InvokesSuccessfully() {
+    MethodCall call = buildMethodCall(METHOD_GET_SAVE_PATH, "Documents", null, "test.txt");
+    plugin.onMethodCall(call, mockResult);
+    verify(mockFileSelectorDelegate).getSavePath(eq(call), any());
     verifyNoInteractions(mockResult);
   }
 

--- a/packages/file_selector/file_selector_android/android/src/test/java/io/flutter/plugins/file_selector/FileSelectorPluginTest.java
+++ b/packages/file_selector/file_selector_android/android/src/test/java/io/flutter/plugins/file_selector/FileSelectorPluginTest.java
@@ -96,8 +96,7 @@ public class FileSelectorPluginTest {
   }
 
   @Test
-  public void
-  onMethodCall_GetSavePath_WhenCalledWithoutSuggestedName_InvokesSuccessfully() {
+  public void onMethodCall_GetSavePath_WhenCalledWithoutSuggestedName_InvokesSuccessfully() {
     MethodCall call = buildMethodCall(METHOD_GET_SAVE_PATH, null, null, null);
     plugin.onMethodCall(call, mockResult);
     verify(mockFileSelectorDelegate).getSavePath(eq(call), any());

--- a/packages/file_selector/file_selector_android/android/src/test/java/io/flutter/plugins/file_selector/PathUtilsTest.java
+++ b/packages/file_selector/file_selector_android/android/src/test/java/io/flutter/plugins/file_selector/PathUtilsTest.java
@@ -1,0 +1,158 @@
+package io.flutter.plugins.file_selector;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import android.app.Activity;
+import android.content.ContentResolver;
+import android.database.Cursor;
+import android.net.Uri;
+import android.provider.MediaStore;
+import android.provider.OpenableColumns;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.Buffer;
+import java.nio.file.Paths;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.shadows.ShadowEnvironment;
+
+@RunWith(RobolectricTestRunner.class)
+public class PathUtilsTest {
+  static TemporaryFolder folder;
+  static final String fileName = "FileName";
+  static final String externalDirectoryName = "ExternalDir";
+  int bufferSize = 1024;
+  final byte[] fakeByte = new byte[bufferSize];
+
+  @Mock Activity mockActivity;
+  @Mock Uri mockUri;
+  @Mock Cursor mockCursor;
+  @Mock ContentResolver mockContentResolver;
+  @Mock InputStream mockInputStream;
+  @Mock Buffer mockBuffer;
+  @Spy PathUtils spyPathUtils;
+
+  @Before
+  public void setUp() throws IOException {
+    MockitoAnnotations.openMocks(this);
+    spyPathUtils = spy(new PathUtils());
+
+    folder = new TemporaryFolder();
+    folder.create();
+
+    when(mockCursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)).thenReturn(0);
+    when(mockContentResolver.query(
+            mockUri,
+            new String[] {OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE},
+            null,
+            null,
+            null))
+        .thenReturn(mockCursor);
+    when(mockActivity.getContentResolver()).thenReturn(mockContentResolver);
+    when(mockInputStream.read(fakeByte)).thenReturn(-1);
+    when(mockContentResolver.openInputStream(mockUri)).thenReturn(mockInputStream);
+    when(mockCursor.moveToFirst()).thenReturn(true);
+    when(mockCursor.getString(0)).thenReturn(fileName);
+    ShadowEnvironment.setExternalStorageDirectory(Paths.get(externalDirectoryName));
+
+    mockFiles();
+  }
+
+  @After
+  public void tearDown() {
+    reset(mockUri);
+    reset(mockActivity);
+    reset(mockCursor);
+    reset(mockContentResolver);
+    reset(mockInputStream);
+    reset(mockBuffer);
+    reset(spyPathUtils);
+    folder.delete();
+  }
+
+  @Test
+  public void getFileName_shouldReturnTheFileName() {
+    final String actualResult =
+        PathUtils.getFileName(
+            mockUri,
+            mockActivity,
+            new String[] {OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE});
+
+    Assert.assertEquals(fileName, actualResult);
+  }
+
+  @Test
+  public void
+      copyFileToInternalStorage_whenExecutedSuccessfully_shouldReturnAbsolutePathOfAddedFolder() {
+    String expectedResult = folder.getRoot() + "\\" + fileName;
+    final String actualResult = PathUtils.copyFileToInternalStorage(mockUri, mockActivity);
+
+    Assert.assertEquals(expectedResult, actualResult);
+  }
+
+  @Test
+  public void getSavePathUri_whenDownloadsUri_ReturnsDownloadFolderFileUri() {
+    Uri uri = Uri.parse("content://com.android.providers.downloads.documents/document/745");
+    when(mockContentResolver.query(
+            uri, new String[] {MediaStore.MediaColumns.DISPLAY_NAME}, null, null, null))
+        .thenReturn(mockCursor);
+    String expected = PathUtils.getSavePathUri(uri, mockActivity);
+
+    Assert.assertEquals(expected, externalDirectoryName + "/Download/" + fileName);
+  }
+
+  @Test
+  public void getSavePathUri_whenExternalStorageUri_ReturnsExternalStorageFileUri()
+      throws IOException {
+    try (MockedStatic<PathUtils> mocked =
+        Mockito.mockStatic(PathUtils.class, Mockito.CALLS_REAL_METHODS)) {
+      String externalDir = "TestDir";
+
+      Uri uri =
+          Uri.parse(
+              "content://com.android.externalstorage.documents/document/primary:"
+                  + externalDir
+                  + "/123");
+      mocked.when(() -> PathUtils.fileExists(anyString())).thenReturn(true);
+
+      when(mockContentResolver.query(
+              uri, new String[] {MediaStore.MediaColumns.DISPLAY_NAME}, null, null, null))
+          .thenReturn(mockCursor);
+
+      String expected = PathUtils.getSavePathUri(uri, mockActivity);
+      Assert.assertEquals(expected, externalDirectoryName + "/" + externalDir + "/" + fileName);
+    }
+  }
+
+  @Test
+  public void getSavePathUri_whenMediaUri_ReturnsMediaFolderFileUri() {
+    Uri uri = Uri.parse("content://com.android.providers.media.documents/document/image:31");
+    String dir = "content://media/external/images/media";
+    when(mockContentResolver.query(
+            Uri.parse(dir), new String[] {"_data"}, "_id=?", new String[] {"31"}, null))
+        .thenReturn(mockCursor);
+    String expected = PathUtils.getSavePathUri(uri, mockActivity);
+
+    Assert.assertEquals(expected, dir + "/" + fileName);
+  }
+
+  private void mockFiles() throws IOException {
+    folder.newFile("myFile1.txt");
+    folder.newFile("myFile2.txt");
+
+    when(mockActivity.getFilesDir()).thenReturn(folder.getRoot());
+  }
+}

--- a/packages/file_selector/file_selector_android/android/src/test/java/io/flutter/plugins/file_selector/TestHelpers.java
+++ b/packages/file_selector/file_selector_android/android/src/test/java/io/flutter/plugins/file_selector/TestHelpers.java
@@ -15,7 +15,10 @@ import java.util.Map;
 
 public class TestHelpers {
   public static MethodCall buildMethodCall(
-      String method, @Nullable String initialDirectory, @Nullable String confirmButtonText, @Nullable String suggestedName) {
+      String method,
+      @Nullable String initialDirectory,
+      @Nullable String confirmButtonText,
+      @Nullable String suggestedName) {
     final Map<String, Object> arguments = new HashMap<>();
     if (initialDirectory != null) {
       arguments.put(_initialDirectory, initialDirectory);

--- a/packages/file_selector/file_selector_android/android/src/test/java/io/flutter/plugins/file_selector/TestHelpers.java
+++ b/packages/file_selector/file_selector_android/android/src/test/java/io/flutter/plugins/file_selector/TestHelpers.java
@@ -6,6 +6,7 @@ package io.flutter.plugins.file_selector;
 
 import static io.flutter.plugins.file_selector.FileSelectorDelegate._confirmButtonText;
 import static io.flutter.plugins.file_selector.FileSelectorDelegate._initialDirectory;
+import static io.flutter.plugins.file_selector.FileSelectorDelegate._suggestedNameKey;
 
 import androidx.annotation.Nullable;
 import io.flutter.plugin.common.MethodCall;
@@ -14,13 +15,16 @@ import java.util.Map;
 
 public class TestHelpers {
   public static MethodCall buildMethodCall(
-      String method, @Nullable String initialDirectory, @Nullable String confirmButtonText) {
+      String method, @Nullable String initialDirectory, @Nullable String confirmButtonText, @Nullable String suggestedName) {
     final Map<String, Object> arguments = new HashMap<>();
     if (initialDirectory != null) {
       arguments.put(_initialDirectory, initialDirectory);
     }
     if (confirmButtonText != null) {
       arguments.put(_confirmButtonText, confirmButtonText);
+    }
+    if (suggestedName != null) {
+      arguments.put(_suggestedNameKey, suggestedName);
     }
 
     return new MethodCall(method, arguments);

--- a/packages/file_selector/file_selector_android/example/android/app/build.gradle
+++ b/packages/file_selector/file_selector_android/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion flutter.compileSdkVersion
+    compileSdkVersion 33
     ndkVersion flutter.ndkVersion
 
     compileOptions {

--- a/packages/file_selector/file_selector_android/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/file_selector/file_selector_android/example/android/app/src/main/AndroidManifest.xml
@@ -1,9 +1,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="io.flutter.plugins.file_selector_example">
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION"/>
+<uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
    <application
         android:label="file_selector_example"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:requestLegacyExternalStorage="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/packages/file_selector/file_selector_android/example/lib/save_text_page.dart
+++ b/packages/file_selector/file_selector_android/example/lib/save_text_page.dart
@@ -5,6 +5,7 @@
 import 'dart:typed_data';
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
 import 'package:flutter/material.dart';
+import 'package:permission_handler/permission_handler.dart';
 
 /// Screen that allows the user to select a save location using `getSavePath`,
 /// then writes text to a file at that location.
@@ -24,6 +25,10 @@ class SaveTextPage extends StatelessWidget {
       // Operation was canceled by the user.
       return;
     }
+
+    await Permission.storage.request().isGranted;
+    await Permission.manageExternalStorage.request().isGranted;
+
     final String text = _contentController.text;
     final Uint8List fileData = Uint8List.fromList(text.codeUnits);
     const String fileMimeType = 'text/plain';

--- a/packages/file_selector/file_selector_android/example/pubspec.yaml
+++ b/packages/file_selector/file_selector_android/example/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_plugin_android_lifecycle: ^2.0.1
+  permission_handler: ^10.0.1
 
 dev_dependencies:
   flutter_lints: ^2.0.0

--- a/packages/file_selector/file_selector_android/lib/file_selector_android.dart
+++ b/packages/file_selector/file_selector_android/lib/file_selector_android.dart
@@ -78,9 +78,9 @@ class FileSelectorAndroid extends FileSelectorPlatform {
     return pathList?.map((String path) => XFile(path)).toList() ?? <XFile>[];
   }
 
-  /// We can't currently set the Confirm Button Text
-  /// For references, please check the following link
-  /// https://developer.android.com/reference/android/content/Intent#ACTION_OPEN_DOCUMENT_TREE
+  // We can't currently set the Confirm Button Text
+  // For references, please check the following link:
+  // https://developer.android.com/reference/android/content/Intent#ACTION_OPEN_DOCUMENT_TREE
   @override
   Future<String?> getDirectoryPath({
     String? initialDirectory,
@@ -94,6 +94,11 @@ class FileSelectorAndroid extends FileSelectorPlatform {
     );
   }
 
+  // We can't currently set the Confirm Button Text
+  // For references, please check the following link:
+  // https://developer.android.com/reference/android/content/Intent#ACTION_CREATE_DOCUMENT
+  // As for MIME types, Android handles the save Intent quite diferently than a desktop OS,
+  // 
   @override
   Future<String?> getSavePath({
     List<XTypeGroup>? acceptedTypeGroups,
@@ -101,17 +106,11 @@ class FileSelectorAndroid extends FileSelectorPlatform {
     String? suggestedName,
     String? confirmButtonText,
   }) async {
-    final List<Map<String, Object>> serializedTypeGroups =
-        _serializeTypeGroups(acceptedTypeGroups);
-
     return _channel.invokeMethod<String>(
       _getSavePathMethod,
       <String, dynamic>{
-        if (serializedTypeGroups.isNotEmpty)
-          _acceptedTypeGroupsKey: serializedTypeGroups,
         _initialDirectoryKey: initialDirectory,
-        _suggestedNameKey: suggestedName,
-        _confirmButtonTextKey: confirmButtonText,
+        _suggestedNameKey: suggestedName
       },
     );
   }

--- a/packages/file_selector/file_selector_android/lib/file_selector_android.dart
+++ b/packages/file_selector/file_selector_android/lib/file_selector_android.dart
@@ -78,9 +78,9 @@ class FileSelectorAndroid extends FileSelectorPlatform {
     return pathList?.map((String path) => XFile(path)).toList() ?? <XFile>[];
   }
 
-  // We can't currently set the Confirm Button Text
-  // For references, please check the following link:
-  // https://developer.android.com/reference/android/content/Intent#ACTION_OPEN_DOCUMENT_TREE
+  /// Android doesn't currently support to set the Confirm Button Text
+  /// For references, please check the following link:
+  /// https://developer.android.com/reference/android/content/Intent#ACTION_OPEN_DOCUMENT_TREE
   @override
   Future<String?> getDirectoryPath({
     String? initialDirectory,
@@ -94,11 +94,11 @@ class FileSelectorAndroid extends FileSelectorPlatform {
     );
   }
 
-  // We can't currently set the Confirm Button Text
-  // For references, please check the following link:
-  // https://developer.android.com/reference/android/content/Intent#ACTION_CREATE_DOCUMENT
-  // As for MIME types, Android handles the save Intent quite diferently than a desktop OS,
-  // 
+  /// Android doesn't currently support to set the Confirm Button Text
+  /// As for MIME types, Android handles the save Intent quite diferently than a desktop OS,
+  /// and doesn't get a list of types to filter in the save action.
+  /// For references, please check the following link:
+  /// https://developer.android.com/reference/android/content/Intent#ACTION_CREATE_DOCUMENT
   @override
   Future<String?> getSavePath({
     List<XTypeGroup>? acceptedTypeGroups,


### PR DESCRIPTION
This PR adds the Android implementation for the `file_selector` package, specifically for the `getSavePath` method.

Issue related: [[file_selector] Add Android support #110098](https://github.com/flutter/flutter/issues/110098)

`getSavePath` receives two possible arguments:
 - initialDirectory: where to save the file, if possible
 - suggestedName: to append a save name for the file to save

This method supports Android SDK 21+ and manages every save path possible. I.e.:
 - ExternalStorage
 - Downloads
 - MediaProviders

Instead of returning a full unparseable URI, it creates a 0B file with the name and type presented and returns the storage path for the user to call the `XFile.saveTo(filePath)` method.

The example does this exactly. It prompts the user to select an optional file name and an optional text to add, launch the intent, and save the file.

We tested this with text in our gifs, but it works with file types, such as base64.

| Android Nougat | Android S |
|---|---|
|![saveAFileNougat](https://user-images.githubusercontent.com/49167576/193103529-502bfbce-232d-492a-b61b-88bb88f246b6.gif)|![saveAFileAndroidS](https://user-images.githubusercontent.com/49167576/193327333-27beca6e-2fc7-4eb6-ba3d-2074c81e0df1.gif)|
