### PR TITLE
📝 #66736 Update documentation

### DIFF
--- a/packages/file_selector/file_selector/README.md
+++ b/packages/file_selector/file_selector/README.md
@@ -6,9 +6,9 @@
 
 A Flutter plugin that manages files and interactions with file dialogs.
 
-|             | iOS    | Linux | macOS  | Web | Windows     |
-|-------------|--------|-------|--------|-----|-------------|
-| **Support** | iOS 9+ | Any   | 10.11+ | Any | Windows 10+ |
+|             | iOS    | Linux | macOS  | Web | Windows     | Android      |
+|-------------|--------|-------|--------|-----|-------------|--------------|
+| **Support** | iOS 9+ | Any   | 10.11+ | Any | Windows 10+ | Android 5.0+ |
 
 ## Usage
 To use this plugin, add `file_selector` as a [dependency in your pubspec.yaml file](https://flutter.dev/platform-plugins/).
@@ -83,12 +83,12 @@ Different platforms support different type group filter options. To avoid
 filters that cover all platforms you are targeting, or that you conditionally
 pass different `XTypeGroup`s based on `Platform`.
 
-|                | Linux | macOS  | Web | Windows     |
-|----------------|-------|--------|-----|-------------|
-| `extensions`   | ✔️     | ✔️      | ✔️   | ✔️           |
-| `mimeTypes`    | ✔️     | ✔️†     | ✔️   |             |
-| `macUTIs`      |       | ✔️      |     |             |
-| `webWildCards` |       |        | ✔️   |             |
+|                | Linux | macOS  | Web | Windows     | Android |
+|----------------|-------|--------|-----|-------------|---------|
+| `extensions`   | ✔️   | ✔️     | ✔️  | ✔️         |         |
+| `mimeTypes`    | ✔️   | ✔️†    | ✔️  |            | ✔️      |
+| `macUTIs`      |      | ✔️     |      |            |         |
+| `webWildCards` |      |         | ✔️  |            |         |
 
 † `mimeTypes` are not supported on version of macOS earlier than 11 (Big Sur).
 


### PR DESCRIPTION
Adds the following:

- Update the table of supported platforms by adding Android.
- Update the type group filter options table by adding the Android one.

![image](https://user-images.githubusercontent.com/64811191/194103625-a6b87927-929a-4a80-bee7-03423423b89d.png)
_Table of supported platforms_

![image](https://user-images.githubusercontent.com/64811191/194103503-85868c68-4415-4243-9280-122c7306b7a8.png)
_Filtering by file types in Android_

_This PR was created to be reviewed by the team._