### PR TITLE
[file_selector] add support for getting multiple directories in Linux

### DIFF
--- a/packages/file_selector/file_selector_linux/.gitignore
+++ b/packages/file_selector/file_selector_linux/.gitignore
@@ -3,3 +3,7 @@
 .flutter-plugins
 .flutter-plugins-dependencies
 pubspec.lock
+
+# Linux specific
+linux/CMakeFiles
+linux/CMakeCache.txt

--- a/packages/file_selector/file_selector_linux/CHANGELOG.md
+++ b/packages/file_selector/file_selector_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.0+2
+
+* Adds `getDirectoriesPaths` implementation.
+
 ## 0.9.0+1
 
 * Changes XTypeGroup initialization from final to const.

--- a/packages/file_selector/file_selector_linux/example/lib/get_multiple_directories_page.dart
+++ b/packages/file_selector/file_selector_linux/example/lib/get_multiple_directories_page.dart
@@ -5,8 +5,8 @@
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
 import 'package:flutter/material.dart';
 
-/// Screen that allows the user to select a directory using `getDirectoryPath`,
-///  then displays the selected directory in a dialog.
+/// Screen that allows the user to select one or more directories using `getDirectoriesPaths`,
+/// then displays the selected directories in a dialog.
 class GetMultipleDirectoriesPage extends StatelessWidget {
   /// Default Constructor
   const GetMultipleDirectoriesPage({Key? key}) : super(key: key);
@@ -63,10 +63,10 @@ class GetMultipleDirectoriesPage extends StatelessWidget {
 /// Widget that displays a text file in a dialog.
 class TextDisplay extends StatelessWidget {
   /// Creates a `TextDisplay`.
-  const TextDisplay(this.directoryPath, {Key? key}) : super(key: key);
+  const TextDisplay(this.directoriesPaths, {Key? key}) : super(key: key);
 
   /// The path selected in the dialog.
-  final String directoryPath;
+  final String directoriesPaths;
 
   @override
   Widget build(BuildContext context) {
@@ -74,7 +74,7 @@ class TextDisplay extends StatelessWidget {
       title: const Text('Selected Directories'),
       content: Scrollbar(
         child: SingleChildScrollView(
-          child: Text(directoryPath),
+          child: Text(directoriesPaths),
         ),
       ),
       actions: <Widget>[

--- a/packages/file_selector/file_selector_linux/example/lib/get_multiple_directories_page.dart
+++ b/packages/file_selector/file_selector_linux/example/lib/get_multiple_directories_page.dart
@@ -1,0 +1,88 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
+import 'package:flutter/material.dart';
+
+/// Screen that allows the user to select a directory using `getDirectoryPath`,
+///  then displays the selected directory in a dialog.
+class GetMultipleDirectoriesPage extends StatelessWidget {
+  /// Default Constructor
+  const GetMultipleDirectoriesPage({Key? key}) : super(key: key);
+
+  Future<void> _getDirectoryPaths(BuildContext context) async {
+    const String confirmButtonText = 'Choose';
+    final List<String>? directoryPaths =
+        await FileSelectorPlatform.instance.getDirectoriesPaths(
+      confirmButtonText: confirmButtonText,
+    );
+    if (directoryPaths == null) {
+      // Operation was canceled by the user.
+      return;
+    }
+    String paths = '';
+    for (final String? path in directoryPaths) {
+      paths += '${path!} \n';
+    }
+    await showDialog<void>(
+      context: context,
+      builder: (BuildContext context) => TextDisplay(paths),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Select multiple directories'),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+                // ignore: deprecated_member_use
+                primary: Colors.blue,
+                // ignore: deprecated_member_use
+                onPrimary: Colors.white,
+              ),
+              child: const Text(
+                  'Press to ask user to choose multiple directories'),
+              onPressed: () => _getDirectoryPaths(context),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Widget that displays a text file in a dialog.
+class TextDisplay extends StatelessWidget {
+  /// Creates a `TextDisplay`.
+  const TextDisplay(this.directoryPath, {Key? key}) : super(key: key);
+
+  /// The path selected in the dialog.
+  final String directoryPath;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Selected Directories'),
+      content: Scrollbar(
+        child: SingleChildScrollView(
+          child: Text(directoryPath),
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          child: const Text('Close'),
+          onPressed: () => Navigator.pop(context),
+        ),
+      ],
+    );
+  }
+}

--- a/packages/file_selector/file_selector_linux/example/lib/home_page.dart
+++ b/packages/file_selector/file_selector_linux/example/lib/home_page.dart
@@ -55,6 +55,13 @@ class HomePage extends StatelessWidget {
               child: const Text('Open a get directory dialog'),
               onPressed: () => Navigator.pushNamed(context, '/directory'),
             ),
+            const SizedBox(height: 10),
+            ElevatedButton(
+              style: style,
+              child: const Text('Open a get multi directories dialog'),
+              onPressed: () =>
+                  Navigator.pushNamed(context, '/multi-directories'),
+            ),
           ],
         ),
       ),

--- a/packages/file_selector/file_selector_linux/example/lib/main.dart
+++ b/packages/file_selector/file_selector_linux/example/lib/main.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 
 import 'get_directory_page.dart';
+import 'get_multiple_directories_page.dart';
 import 'home_page.dart';
 import 'open_image_page.dart';
 import 'open_multiple_images_page.dart';
@@ -36,6 +37,8 @@ class MyApp extends StatelessWidget {
         '/open/text': (BuildContext context) => const OpenTextPage(),
         '/save/text': (BuildContext context) => SaveTextPage(),
         '/directory': (BuildContext context) => const GetDirectoryPage(),
+        '/multi-directories': (BuildContext context) =>
+            const GetMultipleDirectoriesPage()
       },
     );
   }

--- a/packages/file_selector/file_selector_linux/example/pubspec.yaml
+++ b/packages/file_selector/file_selector_linux/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: file_selector_linux_example
 description: Local testbed for Linux file_selector implementation.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: 'none'
 version: 1.0.0+1
 
 environment:
@@ -9,6 +9,7 @@ environment:
 dependencies:
   file_selector_linux:
     path: ../
+  # TODO(adpinola): This should be 2.3.0 once it is published.
   file_selector_platform_interface:
     path: ../../file_selector_platform_interface/
   flutter:

--- a/packages/file_selector/file_selector_linux/example/pubspec.yaml
+++ b/packages/file_selector/file_selector_linux/example/pubspec.yaml
@@ -9,7 +9,8 @@ environment:
 dependencies:
   file_selector_linux:
     path: ../
-  file_selector_platform_interface: ^2.2.0
+  file_selector_platform_interface:
+    path: ../../file_selector_platform_interface/
   flutter:
     sdk: flutter
 

--- a/packages/file_selector/file_selector_linux/lib/file_selector_linux.dart
+++ b/packages/file_selector/file_selector_linux/lib/file_selector_linux.dart
@@ -16,6 +16,7 @@ const String _typeGroupMimeTypesKey = 'mimeTypes';
 const String _openFileMethod = 'openFile';
 const String _getSavePathMethod = 'getSavePath';
 const String _getDirectoryPathMethod = 'getDirectoryPath';
+const String _getDirectoriesPathsMethod = 'getDirectoriesPaths';
 
 const String _acceptedTypeGroupsKey = 'acceptedTypeGroups';
 const String _confirmButtonTextKey = 'confirmButtonText';
@@ -109,6 +110,19 @@ class FileSelectorLinux extends FileSelectorPlatform {
         _confirmButtonTextKey: confirmButtonText,
       },
     );
+  }
+
+  @override
+  Future<List<String>?> getDirectoriesPaths({
+    String? initialDirectory,
+    String? confirmButtonText,
+  }) async {
+    return await _channel
+        .invokeListMethod<String>(_getDirectoriesPathsMethod, <String, dynamic>{
+      _initialDirectoryKey: initialDirectory,
+      _confirmButtonTextKey: confirmButtonText,
+      _multipleKey: true,
+    });
   }
 }
 

--- a/packages/file_selector/file_selector_linux/lib/file_selector_linux.dart
+++ b/packages/file_selector/file_selector_linux/lib/file_selector_linux.dart
@@ -117,7 +117,7 @@ class FileSelectorLinux extends FileSelectorPlatform {
     String? initialDirectory,
     String? confirmButtonText,
   }) async {
-    return await _channel
+    return _channel
         .invokeListMethod<String>(_getDirectoriesPathsMethod, <String, dynamic>{
       _initialDirectoryKey: initialDirectory,
       _confirmButtonTextKey: confirmButtonText,

--- a/packages/file_selector/file_selector_linux/linux/file_selector_plugin.cc
+++ b/packages/file_selector/file_selector_linux/linux/file_selector_plugin.cc
@@ -15,6 +15,7 @@ const char kChannelName[] = "plugins.flutter.dev/file_selector_linux";
 const char kOpenFileMethod[] = "openFile";
 const char kGetSavePathMethod[] = "getSavePath";
 const char kGetDirectoryPathMethod[] = "getDirectoryPath";
+const char kGetDirectoriesPathsMethod[] = "getDirectoriesPaths";
 
 const char kAcceptedTypeGroupsKey[] = "acceptedTypeGroups";
 const char kConfirmButtonTextKey[] = "confirmButtonText";
@@ -131,6 +132,9 @@ GtkFileChooserNative* create_dialog_for_method(GtkWindow* window,
   } else if (strcmp(method, kGetDirectoryPathMethod) == 0) {
     return create_dialog(window, GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
                          "Choose Directory", "_Open", properties);
+  } else if (strcmp(method, kGetDirectoriesPathsMethod) == 0) {
+    return create_dialog(window, GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
+                         "Choose one or more Directories", "_Open", properties);
   } else if (strcmp(method, kGetSavePathMethod) == 0) {
     return create_dialog(window, GTK_FILE_CHOOSER_ACTION_SAVE, "Save File",
                          "_Save", properties);
@@ -192,7 +196,8 @@ static void method_call_cb(FlMethodChannel* channel, FlMethodCall* method_call,
   FlValue* args = fl_method_call_get_args(method_call);
 
   g_autoptr(FlMethodResponse) response = nullptr;
-  if (strcmp(method, kOpenFileMethod) == 0) {
+  if (strcmp(method, kOpenFileMethod) == 0 ||
+      strcmp(method, kGetDirectoriesPathsMethod) == 0) {
     response = show_dialog(self, method, args, true);
   } else if (strcmp(method, kGetDirectoryPathMethod) == 0 ||
              strcmp(method, kGetSavePathMethod) == 0) {

--- a/packages/file_selector/file_selector_linux/linux/test/file_selector_plugin_test.cc
+++ b/packages/file_selector/file_selector_linux/linux/test/file_selector_plugin_test.cc
@@ -169,3 +169,17 @@ TEST(FileSelectorPlugin, TestGetDirectory) {
   EXPECT_EQ(gtk_file_chooser_get_select_multiple(GTK_FILE_CHOOSER(dialog)),
             false);
 }
+
+TEST(FileSelectorPlugin, TestGetMultipleDirectories) {
+  g_autoptr(FlValue) args = fl_value_new_map();
+  fl_value_set_string_take(args, "multiple", fl_value_new_bool(true));
+
+  g_autoptr(GtkFileChooserNative) dialog =
+      create_dialog_for_method(nullptr, "getDirectoriesPaths", args);
+
+  ASSERT_NE(dialog, nullptr);
+  EXPECT_EQ(gtk_file_chooser_get_action(GTK_FILE_CHOOSER(dialog)),
+            GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER);
+  EXPECT_EQ(gtk_file_chooser_get_select_multiple(GTK_FILE_CHOOSER(dialog)),
+            true);  
+}

--- a/packages/file_selector/file_selector_linux/pubspec.yaml
+++ b/packages/file_selector/file_selector_linux/pubspec.yaml
@@ -4,6 +4,8 @@ repository: https://github.com/flutter/plugins/tree/main/packages/file_selector/
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
 version: 0.9.0+1
 
+publish_to: none
+
 environment:
   sdk: ">=2.12.0 <3.0.0"
   flutter: ">=2.10.0"
@@ -18,7 +20,8 @@ flutter:
 
 dependencies:
   cross_file: ^0.3.1
-  file_selector_platform_interface: ^2.2.0
+  file_selector_platform_interface:
+    path: ../file_selector_platform_interface
   flutter:
     sdk: flutter
 

--- a/packages/file_selector/file_selector_linux/pubspec.yaml
+++ b/packages/file_selector/file_selector_linux/pubspec.yaml
@@ -2,8 +2,10 @@ name: file_selector_linux
 description: Liunx implementation of the file_selector plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/file_selector/file_selector_linux
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.9.0+1
+version: 0.9.0+2
 
+# TODO(adpinola): remove this once file_selector_platform_interface version is updated to 2.3.0
+# with getDirectoriesPaths method.
 publish_to: none
 
 environment:
@@ -20,6 +22,7 @@ flutter:
 
 dependencies:
   cross_file: ^0.3.1
+  # TODO(adpinola): This should be 2.3.0 once it is published.
   file_selector_platform_interface:
     path: ../file_selector_platform_interface
   flutter:

--- a/packages/file_selector/file_selector_linux/test/file_selector_linux_test.dart
+++ b/packages/file_selector/file_selector_linux/test/file_selector_linux_test.dart
@@ -386,4 +386,50 @@ void main() {
       );
     });
   });
+
+    group('#getDirectoriesPaths', () {
+    test('passes initialDirectory correctly', () async {
+      await plugin.getDirectoriesPaths(initialDirectory: '/example/directory');
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('getDirectoriesPaths', arguments: <String, dynamic>{
+            'initialDirectory': '/example/directory',
+            'confirmButtonText': null,
+            'multiple': true,
+          }),
+        ],
+      );
+    });
+    test('passes confirmButtonText correctly', () async {
+      await plugin.getDirectoriesPaths(confirmButtonText: 'Open File');
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('getDirectoriesPaths', arguments: <String, dynamic>{
+            'initialDirectory': null,
+            'confirmButtonText': 'Open File',
+            'multiple': true,
+          }),
+        ],
+      );
+    });
+    test('passes multiple flag correctly', () async {
+      await plugin.getDirectoriesPaths();
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('getDirectoriesPaths', arguments: <String, dynamic>{
+            'initialDirectory': null,
+            'confirmButtonText': null,
+            'multiple': true,
+          }),
+        ],
+      );
+    });
+
+  });
 }

--- a/packages/file_selector/file_selector_linux/test/file_selector_linux_test.dart
+++ b/packages/file_selector/file_selector_linux/test/file_selector_linux_test.dart
@@ -387,7 +387,7 @@ void main() {
     });
   });
 
-    group('#getDirectoriesPaths', () {
+  group('#getDirectoriesPaths', () {
     test('passes initialDirectory correctly', () async {
       await plugin.getDirectoriesPaths(initialDirectory: '/example/directory');
 
@@ -430,6 +430,5 @@ void main() {
         ],
       );
     });
-
   });
 }


### PR DESCRIPTION
This PR adds the Linux implementation for retrieving multiple directories paths from a select folder dialog.

Issue: [Support for selection of multiple directories, through desktop's native open panel, in 'file_selector' package #74323](https://github.com/flutter/flutter/issues/74323)

![VirtualBoxVM_rwSR7C6lcO](https://user-images.githubusercontent.com/57049542/195621047-e2ab8a52-db9e-4821-bfbc-6377d35ba6e0.png)
_New option on example application_

![image](https://user-images.githubusercontent.com/57049542/195607284-ada5d921-9770-46fb-9337-a9d6bf79f718.png)
_GetDirectoriesPaths_

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
