### PR TITLE
[file_selector] Add support for getting multiple directories in macOS

### DIFF
--- a/packages/file_selector/file_selector/CHANGELOG.md
+++ b/packages/file_selector/file_selector/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.2+2
+
+* Adds `getDirectoriesPaths` method.
+
 ## 0.9.2+1
 
 * Changes XTypeGroup initialization from final to const.

--- a/packages/file_selector/file_selector/CHANGELOG.md
+++ b/packages/file_selector/file_selector/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.9.2+2
 
-* Adds `getDirectoriesPaths` method.
+* Adds `getDirectoryPaths` method.
 
 ## 0.9.2+1
 

--- a/packages/file_selector/file_selector/CHANGELOG.md
+++ b/packages/file_selector/file_selector/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.9.2+2
 
-* Adds `getDirectoryPaths` method.
+* Adds `getDirectoriesPaths` method.
 
 ## 0.9.2+1
 

--- a/packages/file_selector/file_selector/lib/file_selector.dart
+++ b/packages/file_selector/file_selector/lib/file_selector.dart
@@ -123,3 +123,22 @@ Future<String?> getDirectoryPath({
   return FileSelectorPlatform.instance.getDirectoryPath(
       initialDirectory: initialDirectory, confirmButtonText: confirmButtonText);
 }
+
+/// Opens a directory selection dialog and returns a list of the paths chosen by the user.
+/// This always returns `null` on the web.
+///
+/// [initialDirectory] is the full path to the directory that will be displayed
+/// when the dialog is opened. When not provided, the platform will pick an
+/// initial location.
+///
+/// [confirmButtonText] is the text in the confirmation button of the dialog.
+/// When not provided, the default OS label is used (for example, "Open").
+///
+/// Returns `null` if the user cancels the operation.
+Future<List<String?>?> getDirectoryPaths({
+  String? initialDirectory,
+  String? confirmButtonText,
+}) async {
+  return FileSelectorPlatform.instance.getDirectoryPaths(
+      initialDirectory: initialDirectory, confirmButtonText: confirmButtonText);
+}

--- a/packages/file_selector/file_selector/lib/file_selector.dart
+++ b/packages/file_selector/file_selector/lib/file_selector.dart
@@ -135,10 +135,10 @@ Future<String?> getDirectoryPath({
 /// When not provided, the default OS label is used (for example, "Open").
 ///
 /// Returns `null` if the user cancels the operation.
-Future<List<String?>?> getDirectoryPaths({
+Future<List<String?>?> getDirectoriesPaths({
   String? initialDirectory,
   String? confirmButtonText,
 }) async {
-  return FileSelectorPlatform.instance.getDirectoryPaths(
+  return FileSelectorPlatform.instance.getDirectoriesPaths(
       initialDirectory: initialDirectory, confirmButtonText: confirmButtonText);
 }

--- a/packages/file_selector/file_selector/pubspec.yaml
+++ b/packages/file_selector/file_selector/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for opening and saving files, or selecting
   directories, using native file selection UI.
 repository: https://github.com/flutter/plugins/tree/main/packages/file_selector/file_selector
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.9.2+1
+version: 0.9.2+2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/file_selector/file_selector/test/file_selector_test.dart
+++ b/packages/file_selector/file_selector/test/file_selector_test.dart
@@ -259,7 +259,7 @@ void main() {
     });
   });
 
-  group('getDirectoryPaths', () {
+  group('getDirectoriesPaths', () {
     const List<String> expectedDirectoryPaths = <String>[
       '/example/path',
       '/example/2/path'
@@ -272,7 +272,7 @@ void main() {
             confirmButtonText: confirmButtonText)
         ..setPathsResponse(expectedDirectoryPaths);
 
-      final List<String?>? directoryPaths = await getDirectoryPaths(
+      final List<String?>? directoryPaths = await getDirectoriesPaths(
         initialDirectory: initialDirectory,
         confirmButtonText: confirmButtonText,
       );
@@ -283,7 +283,7 @@ void main() {
     test('works with no arguments', () async {
       fakePlatformImplementation.setPathsResponse(expectedDirectoryPaths);
 
-      final List<String?>? directoryPaths = await getDirectoryPaths();
+      final List<String?>? directoryPaths = await getDirectoriesPaths();
       expect(directoryPaths, expectedDirectoryPaths);
     });
 
@@ -293,7 +293,7 @@ void main() {
         ..setPathsResponse(expectedDirectoryPaths);
 
       final List<String?>? directoryPaths =
-          await getDirectoryPaths(initialDirectory: initialDirectory);
+          await getDirectoriesPaths(initialDirectory: initialDirectory);
       expect(directoryPaths, expectedDirectoryPaths);
     });
 
@@ -303,7 +303,7 @@ void main() {
         ..setPathsResponse(expectedDirectoryPaths);
 
       final List<String?>? directoryPaths =
-          await getDirectoryPaths(confirmButtonText: confirmButtonText);
+          await getDirectoriesPaths(confirmButtonText: confirmButtonText);
       expect(directoryPaths, expectedDirectoryPaths);
     });
   });
@@ -398,7 +398,7 @@ class FakeFileSelector extends Fake
   }
 
   @override
-  Future<List<String?>?> getDirectoryPaths({
+  Future<List<String?>?> getDirectoriesPaths({
     String? initialDirectory,
     String? confirmButtonText,
   }) async {

--- a/packages/file_selector/file_selector/test/file_selector_test.dart
+++ b/packages/file_selector/file_selector/test/file_selector_test.dart
@@ -258,55 +258,6 @@ void main() {
       expect(directoryPath, expectedDirectoryPath);
     });
   });
-
-  group('getDirectoriesPaths', () {
-    const List<String> expectedDirectoryPaths = <String>[
-      '/example/path',
-      '/example/2/path'
-    ];
-
-    test('works', () async {
-      fakePlatformImplementation
-        ..setExpectations(
-            initialDirectory: initialDirectory,
-            confirmButtonText: confirmButtonText)
-        ..setPathsResponse(expectedDirectoryPaths);
-
-      final List<String?>? directoryPaths = await getDirectoriesPaths(
-        initialDirectory: initialDirectory,
-        confirmButtonText: confirmButtonText,
-      );
-
-      expect(directoryPaths, expectedDirectoryPaths);
-    });
-
-    test('works with no arguments', () async {
-      fakePlatformImplementation.setPathsResponse(expectedDirectoryPaths);
-
-      final List<String?>? directoryPaths = await getDirectoriesPaths();
-      expect(directoryPaths, expectedDirectoryPaths);
-    });
-
-    test('sets the initial directory', () async {
-      fakePlatformImplementation
-        ..setExpectations(initialDirectory: initialDirectory)
-        ..setPathsResponse(expectedDirectoryPaths);
-
-      final List<String?>? directoryPaths =
-          await getDirectoriesPaths(initialDirectory: initialDirectory);
-      expect(directoryPaths, expectedDirectoryPaths);
-    });
-
-    test('sets the button confirmation label', () async {
-      fakePlatformImplementation
-        ..setExpectations(confirmButtonText: confirmButtonText)
-        ..setPathsResponse(expectedDirectoryPaths);
-
-      final List<String?>? directoryPaths =
-          await getDirectoriesPaths(confirmButtonText: confirmButtonText);
-      expect(directoryPaths, expectedDirectoryPaths);
-    });
-  });
 }
 
 class FakeFileSelector extends Fake
@@ -395,15 +346,5 @@ class FakeFileSelector extends Fake
     expect(initialDirectory, this.initialDirectory);
     expect(confirmButtonText, this.confirmButtonText);
     return path;
-  }
-
-  @override
-  Future<List<String?>?> getDirectoriesPaths({
-    String? initialDirectory,
-    String? confirmButtonText,
-  }) async {
-    expect(initialDirectory, this.initialDirectory);
-    expect(confirmButtonText, this.confirmButtonText);
-    return paths;
   }
 }

--- a/packages/file_selector/file_selector/test/file_selector_test.dart
+++ b/packages/file_selector/file_selector/test/file_selector_test.dart
@@ -258,6 +258,55 @@ void main() {
       expect(directoryPath, expectedDirectoryPath);
     });
   });
+
+  group('getDirectoryPaths', () {
+    const List<String> expectedDirectoryPaths = <String>[
+      '/example/path',
+      '/example/2/path'
+    ];
+
+    test('works', () async {
+      fakePlatformImplementation
+        ..setExpectations(
+            initialDirectory: initialDirectory,
+            confirmButtonText: confirmButtonText)
+        ..setPathsResponse(expectedDirectoryPaths);
+
+      final List<String?>? directoryPaths = await getDirectoryPaths(
+        initialDirectory: initialDirectory,
+        confirmButtonText: confirmButtonText,
+      );
+
+      expect(directoryPaths, expectedDirectoryPaths);
+    });
+
+    test('works with no arguments', () async {
+      fakePlatformImplementation.setPathsResponse(expectedDirectoryPaths);
+
+      final List<String?>? directoryPaths = await getDirectoryPaths();
+      expect(directoryPaths, expectedDirectoryPaths);
+    });
+
+    test('sets the initial directory', () async {
+      fakePlatformImplementation
+        ..setExpectations(initialDirectory: initialDirectory)
+        ..setPathsResponse(expectedDirectoryPaths);
+
+      final List<String?>? directoryPaths =
+          await getDirectoryPaths(initialDirectory: initialDirectory);
+      expect(directoryPaths, expectedDirectoryPaths);
+    });
+
+    test('sets the button confirmation label', () async {
+      fakePlatformImplementation
+        ..setExpectations(confirmButtonText: confirmButtonText)
+        ..setPathsResponse(expectedDirectoryPaths);
+
+      final List<String?>? directoryPaths =
+          await getDirectoryPaths(confirmButtonText: confirmButtonText);
+      expect(directoryPaths, expectedDirectoryPaths);
+    });
+  });
 }
 
 class FakeFileSelector extends Fake
@@ -271,6 +320,7 @@ class FakeFileSelector extends Fake
   // Return values.
   List<XFile>? files;
   String? path;
+  List<String?>? paths;
 
   void setExpectations({
     List<XTypeGroup> acceptedTypeGroups = const <XTypeGroup>[],
@@ -292,6 +342,11 @@ class FakeFileSelector extends Fake
   // ignore: use_setters_to_change_properties
   void setPathResponse(String path) {
     this.path = path;
+  }
+
+  // ignore: use_setters_to_change_properties
+  void setPathsResponse(List<String> paths) {
+    this.paths = paths;
   }
 
   @override
@@ -340,5 +395,15 @@ class FakeFileSelector extends Fake
     expect(initialDirectory, this.initialDirectory);
     expect(confirmButtonText, this.confirmButtonText);
     return path;
+  }
+
+  @override
+  Future<List<String?>?> getDirectoryPaths({
+    String? initialDirectory,
+    String? confirmButtonText,
+  }) async {
+    expect(initialDirectory, this.initialDirectory);
+    expect(confirmButtonText, this.confirmButtonText);
+    return paths;
   }
 }

--- a/packages/file_selector/file_selector_macos/CHANGELOG.md
+++ b/packages/file_selector/file_selector_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.0+4
+
+* Adds getDirectoriesPaths method
+
 ## 0.9.0+3
 
 * Changes XTypeGroup initialization from final to const.

--- a/packages/file_selector/file_selector_macos/example/lib/get_multiple_directories_page.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/get_multiple_directories_page.dart
@@ -1,0 +1,88 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
+import 'package:flutter/material.dart';
+
+/// Screen that allows the user to select a directory using `getDirectoryPath`,
+///  then displays the selected directory in a dialog.
+class GetMultipleDirectoriesPage extends StatelessWidget {
+  /// Default Constructor
+  const GetMultipleDirectoriesPage({Key? key}) : super(key: key);
+
+  Future<void> _getDirectoriesPaths(BuildContext context) async {
+    const String confirmButtonText = 'Choose';
+    final List<String?> directoryPaths =
+        await FileSelectorPlatform.instance.getDirectoriesPaths(
+      confirmButtonText: confirmButtonText,
+    );
+    if (directoryPaths == null) {
+      // Operation was canceled by the user.
+      return;
+    }
+    String paths = '';
+    for (final String? path in directoryPaths) {
+      paths += '${path!} \n';
+    }
+    await showDialog<void>(
+      context: context,
+      builder: (BuildContext context) => TextDisplay(paths),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Select multiple directories'),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+                // ignore: deprecated_member_use
+                primary: Colors.blue,
+                // ignore: deprecated_member_use
+                onPrimary: Colors.white,
+              ),
+              child: const Text(
+                  'Press to ask user to choose multiple directories'),
+              onPressed: () => _getDirectoriesPaths(context),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Widget that displays a text file in a dialog.
+class TextDisplay extends StatelessWidget {
+  /// Creates a `TextDisplay`.
+  const TextDisplay(this.directoryPath, {Key? key}) : super(key: key);
+
+  /// The path selected in the dialog.
+  final String directoryPath;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Selected Directories'),
+      content: Scrollbar(
+        child: SingleChildScrollView(
+          child: Text(directoryPath),
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          child: const Text('Close'),
+          onPressed: () => Navigator.pop(context),
+        ),
+      ],
+    );
+  }
+}

--- a/packages/file_selector/file_selector_macos/example/lib/home_page.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/home_page.dart
@@ -55,6 +55,12 @@ class HomePage extends StatelessWidget {
               child: const Text('Open a get directory dialog'),
               onPressed: () => Navigator.pushNamed(context, '/directory'),
             ),
+            const SizedBox(height: 10),
+            ElevatedButton(
+              style: style,
+              child: const Text('Open a get multi directories dialog'),
+              onPressed: () => Navigator.pushNamed(context, '/multi-directories'),
+            ),
           ],
         ),
       ),

--- a/packages/file_selector/file_selector_macos/example/lib/main.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/main.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 
 import 'get_directory_page.dart';
+import 'get_multiple_directories_page.dart';
 import 'home_page.dart';
 import 'open_image_page.dart';
 import 'open_multiple_images_page.dart';
@@ -36,6 +37,7 @@ class MyApp extends StatelessWidget {
         '/open/text': (BuildContext context) => const OpenTextPage(),
         '/save/text': (BuildContext context) => SaveTextPage(),
         '/directory': (BuildContext context) => const GetDirectoryPage(),
+        '/multi-directories': (BuildContext context) => const GetMultipleDirectoriesPage(),
       },
     );
   }

--- a/packages/file_selector/file_selector_macos/lib/file_selector_macos.dart
+++ b/packages/file_selector/file_selector_macos/lib/file_selector_macos.dart
@@ -88,6 +88,22 @@ class FileSelectorMacOS extends FileSelectorPlatform {
     );
   }
 
+  @override
+  Future<List<String?>> getDirectoriesPaths({
+    String? initialDirectory,
+    String? confirmButtonText,
+  }) async {
+      final List<String?>? pathList = await _channel.invokeListMethod<String>(
+      'getDirectoriesPaths',
+      <String, dynamic>{
+        'initialDirectory': initialDirectory,
+        'confirmButtonText': confirmButtonText,
+        'multiple': true,
+      },
+    );
+    return pathList ?? <String>[];
+  }
+
   // Converts the type group list into a flat list of all allowed types, since
   // macOS doesn't support filter groups.
   Map<String, List<String>>? _allowedTypeListFromTypeGroups(

--- a/packages/file_selector/file_selector_macos/macos/Classes/FileSelectorPlugin.swift
+++ b/packages/file_selector/file_selector_macos/macos/Classes/FileSelectorPlugin.swift
@@ -47,6 +47,7 @@ public class FileSelectorPlugin: NSObject, FlutterPlugin {
   private let openMethod = "openFile"
   private let openDirectoryMethod = "getDirectoryPath"
   private let saveMethod = "getSavePath"
+  private let openDirectoriesMethod = "getDirectoriesPaths"
 
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(
@@ -67,11 +68,14 @@ public class FileSelectorPlugin: NSObject, FlutterPlugin {
     let arguments = (call.arguments ?? [:]) as! [String: Any]
     switch call.method {
     case openMethod,
-         openDirectoryMethod:
+         openDirectoryMethod,
+         openDirectoriesMethod:
       let choosingDirectory = call.method == openDirectoryMethod
+      let choosingDirectories = call.method == openDirectoriesMethod
       let panel = NSOpenPanel()
       configure(panel: panel, with: arguments)
-      configure(openPanel: panel, with: arguments, choosingDirectory: choosingDirectory)
+      if (choosingDirectories) { configure(openPanel: panel, with: arguments, choosingDirectory: choosingDirectories) }
+      if (choosingDirectory) { configure(openPanel: panel, with: arguments, choosingDirectory: choosingDirectory ) }
       panelController.display(panel, for: viewProvider.view?.window) { (selection: [URL]?) in
         if (choosingDirectory) {
           result(selection?.first?.path)

--- a/packages/file_selector/file_selector_macos/pubspec.yaml
+++ b/packages/file_selector/file_selector_macos/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_selector_macos
 description: macOS implementation of the file_selector plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/file_selector/file_selector_macos
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.9.0+3
+version: 0.9.0+4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/file_selector/file_selector_macos/test/file_selector_macos_test.dart
+++ b/packages/file_selector/file_selector_macos/test/file_selector_macos_test.dart
@@ -355,4 +355,51 @@ void main() {
       ],
     );
   });
+
+  group('getDirectoryPaths', () {
+    test('passes initialDirectory correctly', () async {
+      await plugin.getDirectoriesPaths(initialDirectory: '/example/directory');
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('getDirectoriesPaths', arguments: <String, dynamic>{
+            'initialDirectory': '/example/directory',
+            'confirmButtonText': null,
+            'multiple': true
+          }),
+        ],
+      );
+    });
+
+    test('passes confirmButtonText correctly', () async {
+      await plugin.getDirectoriesPaths(confirmButtonText: 'Open Directories');
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('getDirectoriesPaths', arguments: <String, dynamic>{
+            'initialDirectory': null,
+            'confirmButtonText': 'Open Directories',
+            'multiple': true
+          }),
+        ],
+      );
+    });
+
+    test('receives argument multiple as true even if the others are null', () async {
+      await plugin.getDirectoriesPaths();
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('getDirectoriesPaths', arguments: <String, dynamic>{
+            'initialDirectory': null,
+            'confirmButtonText': null,
+            'multiple': true
+          }),
+        ],
+      );
+    });
+  });
 }


### PR DESCRIPTION
This PR adds the macOS implementation for retrieving multiple directories paths from a select folder dialog.

Issue: https://github.com/flutter/flutter/issues/74323

![Screen Shot 2022-10-13 at 12 08 59 PM](https://user-images.githubusercontent.com/64811191/195640188-c252ca1e-40e7-473a-9f85-3091925905c5.png)

![Screen Shot 2022-10-13 at 12 09 16 PM](https://user-images.githubusercontent.com/64811191/195640193-3f8a8613-da2e-4f2a-b0b0-6e32e370a12e.png)
