### PR TITLE
[file_selector] Add getDirectoriesPaths method to the file_selector_platform_interface.

### DIFF
--- a/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
+++ b/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0+1
+
+* Adds `getDirectoriesPaths` method to interface.
+
 ## 2.2.0
 
 * Makes `XTypeGroup`'s constructor constant.

--- a/packages/file_selector/file_selector_platform_interface/lib/src/method_channel/method_channel_file_selector.dart
+++ b/packages/file_selector/file_selector_platform_interface/lib/src/method_channel/method_channel_file_selector.dart
@@ -93,4 +93,18 @@ class MethodChannelFileSelector extends FileSelectorPlatform {
       },
     );
   }
+
+  /// Gets a list of directories paths from a dialog
+  @override
+  Future<List<String>?> getDirectoriesPaths(
+      {String? initialDirectory, String? confirmButtonText}) async {
+    return _channel.invokeListMethod<String>(
+      'getDirectoriesPaths',
+      <String, dynamic>{
+        'initialDirectory': initialDirectory,
+        'confirmButtonText': confirmButtonText,
+        'multiple': true,
+      },
+    );
+  }
 }

--- a/packages/file_selector/file_selector_platform_interface/lib/src/platform_interface/file_selector_interface.dart
+++ b/packages/file_selector/file_selector_platform_interface/lib/src/platform_interface/file_selector_interface.dart
@@ -74,4 +74,13 @@ abstract class FileSelectorPlatform extends PlatformInterface {
   }) {
     throw UnimplementedError('getDirectoryPath() has not been implemented.');
   }
+
+  /// Open file dialog for loading directories and return multiple directories paths
+  /// Returns `null` if user cancels the operation.
+  Future<List<String?>> getDirectoriesPaths({
+    String? initialDirectory,
+    String? confirmButtonText,
+  }) {
+    throw UnimplementedError('getDirectoriesPaths() has not been implemented.');
+  }
 }

--- a/packages/file_selector/file_selector_platform_interface/lib/src/platform_interface/file_selector_interface.dart
+++ b/packages/file_selector/file_selector_platform_interface/lib/src/platform_interface/file_selector_interface.dart
@@ -77,7 +77,7 @@ abstract class FileSelectorPlatform extends PlatformInterface {
 
   /// Open file dialog for loading directories and return multiple directories paths
   /// Returns `null` if user cancels the operation.
-  Future<List<String?>> getDirectoriesPaths({
+  Future<List<String>?> getDirectoriesPaths({
     String? initialDirectory,
     String? confirmButtonText,
   }) {

--- a/packages/file_selector/file_selector_platform_interface/pubspec.yaml
+++ b/packages/file_selector/file_selector_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/main/packages/file_selector/
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.2.0
+version: 2.2.0+1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/file_selector/file_selector_platform_interface/test/method_channel_file_selector_test.dart
+++ b/packages/file_selector/file_selector_platform_interface/test/method_channel_file_selector_test.dart
@@ -247,6 +247,37 @@ void main() {
           );
         });
       });
+      group('#getDirectoriesPaths', () {
+        test('passes initialDirectory correctly', () async {
+          await plugin.getDirectoriesPaths(
+              initialDirectory: '/example/directory');
+
+          expect(
+            log,
+            <Matcher>[
+              isMethodCall('getDirectoriesPaths', arguments: <String, dynamic>{
+                'initialDirectory': '/example/directory',
+                'confirmButtonText': null,
+                'multiple': true
+              }),
+            ],
+          );
+        });
+        test('passes confirmButtonText correctly', () async {
+          await plugin.getDirectoriesPaths(confirmButtonText: 'Open File');
+
+          expect(
+            log,
+            <Matcher>[
+              isMethodCall('getDirectoriesPaths', arguments: <String, dynamic>{
+                'initialDirectory': null,
+                'confirmButtonText': 'Open File',
+                'multiple': true
+              }),
+            ],
+          );
+        });
+      });
     });
   });
 }


### PR DESCRIPTION
This PR adds the implementation of the method `getDirectoriesPaths` to the `file_selector_platform_interface`.

Next, we will proceed this way:
1. Add implementations for Windows, macOS and Linux in parallel. (The Windows implementation will be done when the [Dart migration](https://github.com/flutter/plugins/pull/6568) is ready)
2. Add the new published version to the file_selector package with its example when at least one platform is published.
3. Repeat 2 when the other new implementations are published.

Issue:
[Support for selection of multiple directories, through desktop's native open panel, in 'file_selector' package #74323](https://github.com/flutter/flutter/issues/74323)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
