### PR TITLE
[file_selector] Add support for getting multiple directories in macOS

### DIFF
--- a/packages/file_selector/file_selector_macos/CHANGELOG.md
+++ b/packages/file_selector/file_selector_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.0+4
+
+* Adds `getDirectoriesPaths` method.
+
 ## 0.9.0+3
 
 * Changes XTypeGroup initialization from final to const.

--- a/packages/file_selector/file_selector_macos/example/lib/get_multiple_directories_page.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/get_multiple_directories_page.dart
@@ -1,0 +1,88 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
+import 'package:flutter/material.dart';
+
+/// Screen that allows the user to select one or more directories using `getDirectoriesPaths`,
+/// then displays the selected directories in a dialog.
+class GetMultipleDirectoriesPage extends StatelessWidget {
+  /// Default Constructor
+  const GetMultipleDirectoriesPage({Key? key}) : super(key: key);
+
+  Future<void> _getDirectoriesPaths(BuildContext context) async {
+    const String confirmButtonText = 'Choose';
+    final List<String>? directoriesPaths =
+        await FileSelectorPlatform.instance.getDirectoriesPaths(
+      confirmButtonText: confirmButtonText,
+    );
+    if (directoriesPaths == null) {
+      // Operation was canceled by the user.
+      return;
+    }
+    String paths = '';
+    for (final String? path in directoriesPaths) {
+      paths += '${path!} \n';
+    }
+    await showDialog<void>(
+      context: context,
+      builder: (BuildContext context) => TextDisplay(paths),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Select multiple directories'),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+                // ignore: deprecated_member_use
+                primary: Colors.blue,
+                // ignore: deprecated_member_use
+                onPrimary: Colors.white,
+              ),
+              child: const Text(
+                  'Press to ask user to choose multiple directories'),
+              onPressed: () => _getDirectoriesPaths(context),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Widget that displays a text file in a dialog.
+class TextDisplay extends StatelessWidget {
+  /// Creates a `TextDisplay`.
+  const TextDisplay(this.directoryPath, {Key? key}) : super(key: key);
+
+  /// The path selected in the dialog.
+  final String directoryPath;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Selected Directories'),
+      content: Scrollbar(
+        child: SingleChildScrollView(
+          child: Text(directoryPath),
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          child: const Text('Close'),
+          onPressed: () => Navigator.pop(context),
+        ),
+      ],
+    );
+  }
+}

--- a/packages/file_selector/file_selector_macos/example/lib/home_page.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/home_page.dart
@@ -55,6 +55,13 @@ class HomePage extends StatelessWidget {
               child: const Text('Open a get directory dialog'),
               onPressed: () => Navigator.pushNamed(context, '/directory'),
             ),
+            const SizedBox(height: 10),
+            ElevatedButton(
+              style: style,
+              child: const Text('Open a get multi directories dialog'),
+              onPressed: () =>
+                  Navigator.pushNamed(context, '/multi-directories'),
+            ),
           ],
         ),
       ),

--- a/packages/file_selector/file_selector_macos/example/lib/main.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/main.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 
 import 'get_directory_page.dart';
+import 'get_multiple_directories_page.dart';
 import 'home_page.dart';
 import 'open_image_page.dart';
 import 'open_multiple_images_page.dart';
@@ -36,6 +37,8 @@ class MyApp extends StatelessWidget {
         '/open/text': (BuildContext context) => const OpenTextPage(),
         '/save/text': (BuildContext context) => SaveTextPage(),
         '/directory': (BuildContext context) => const GetDirectoryPage(),
+        '/multi-directories': (BuildContext context) =>
+            const GetMultipleDirectoriesPage(),
       },
     );
   }

--- a/packages/file_selector/file_selector_macos/example/pubspec.yaml
+++ b/packages/file_selector/file_selector_macos/example/pubspec.yaml
@@ -15,7 +15,9 @@ dependencies:
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.
     path: ..
-  file_selector_platform_interface: ^2.2.0
+  # TODO(VanesaOshiro): This should be 2.3.0 once it is published.
+  file_selector_platform_interface:
+    path: ../../file_selector_platform_interface/
   flutter:
     sdk: flutter
 

--- a/packages/file_selector/file_selector_macos/lib/file_selector_macos.dart
+++ b/packages/file_selector/file_selector_macos/lib/file_selector_macos.dart
@@ -88,6 +88,21 @@ class FileSelectorMacOS extends FileSelectorPlatform {
     );
   }
 
+  @override
+  Future<List<String>?> getDirectoriesPaths({
+    String? initialDirectory,
+    String? confirmButtonText,
+  }) async {
+    return await _channel.invokeListMethod<String>(
+      'getDirectoriesPaths',
+      <String, dynamic>{
+        'initialDirectory': initialDirectory,
+        'confirmButtonText': confirmButtonText,
+        'multiple': true,
+      },
+    );
+  }
+
   // Converts the type group list into a flat list of all allowed types, since
   // macOS doesn't support filter groups.
   Map<String, List<String>>? _allowedTypeListFromTypeGroups(

--- a/packages/file_selector/file_selector_macos/macos/Classes/FileSelectorPlugin.swift
+++ b/packages/file_selector/file_selector_macos/macos/Classes/FileSelectorPlugin.swift
@@ -46,6 +46,7 @@ public class FileSelectorPlugin: NSObject, FlutterPlugin {
 
   private let openMethod = "openFile"
   private let openDirectoryMethod = "getDirectoryPath"
+  private let openDirectoriesMethod = "getDirectoriesPaths"
   private let saveMethod = "getSavePath"
 
   public static func register(with registrar: FlutterPluginRegistrar) {
@@ -67,11 +68,14 @@ public class FileSelectorPlugin: NSObject, FlutterPlugin {
     let arguments = (call.arguments ?? [:]) as! [String: Any]
     switch call.method {
     case openMethod,
-         openDirectoryMethod:
+         openDirectoryMethod,
+         openDirectoriesMethod:
       let choosingDirectory = call.method == openDirectoryMethod
+      let choosingDirectories = call.method == openDirectoriesMethod
       let panel = NSOpenPanel()
       configure(panel: panel, with: arguments)
-      configure(openPanel: panel, with: arguments, choosingDirectory: choosingDirectory)
+      if (choosingDirectories) { configure(openPanel: panel, with: arguments, choosingDirectory: choosingDirectories) }
+      if (choosingDirectory) { configure(openPanel: panel, with: arguments, choosingDirectory: choosingDirectory) }
       panelController.display(panel, for: viewProvider.view?.window) { (selection: [URL]?) in
         if (choosingDirectory) {
           result(selection?.first?.path)

--- a/packages/file_selector/file_selector_macos/pubspec.yaml
+++ b/packages/file_selector/file_selector_macos/pubspec.yaml
@@ -2,7 +2,11 @@ name: file_selector_macos
 description: macOS implementation of the file_selector plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/file_selector/file_selector_macos
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.9.0+3
+version: 0.9.0+4
+
+# TODO(VanesaOshiro): remove this once file_selector_platform_interface version is updated to 2.3.0
+# with getDirectoriesPaths method.
+publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -18,7 +22,9 @@ flutter:
 
 dependencies:
   cross_file: ^0.3.1
-  file_selector_platform_interface: ^2.2.0
+   # TODO(VanesaOshiro): This should be 2.3.0 once it is published.
+  file_selector_platform_interface:
+    path: ../../file_selector_platform_interface/
   flutter:
     sdk: flutter
 

--- a/packages/file_selector/file_selector_macos/test/file_selector_macos_test.dart
+++ b/packages/file_selector/file_selector_macos/test/file_selector_macos_test.dart
@@ -355,4 +355,52 @@ void main() {
       ],
     );
   });
+
+  group('getDirectoryPaths', () {
+    test('passes initialDirectory correctly', () async {
+      await plugin.getDirectoriesPaths(initialDirectory: '/example/directory');
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('getDirectoriesPaths', arguments: <String, dynamic>{
+            'initialDirectory': '/example/directory',
+            'confirmButtonText': null,
+            'multiple': true
+          }),
+        ],
+      );
+    });
+
+    test('passes confirmButtonText correctly', () async {
+      await plugin.getDirectoriesPaths(confirmButtonText: 'Open Directories');
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('getDirectoriesPaths', arguments: <String, dynamic>{
+            'initialDirectory': null,
+            'confirmButtonText': 'Open Directories',
+            'multiple': true
+          }),
+        ],
+      );
+    });
+
+    test('receives argument multiple as true even if the others are null',
+        () async {
+      await plugin.getDirectoriesPaths();
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('getDirectoriesPaths', arguments: <String, dynamic>{
+            'initialDirectory': null,
+            'confirmButtonText': null,
+            'multiple': true
+          }),
+        ],
+      );
+    });
+  });
 }


### PR DESCRIPTION
This PR adds the macOS implementation for retrieving multiple directories paths from a select folder dialog.

Issue: https://github.com/flutter/flutter/issues/74323

![image](https://user-images.githubusercontent.com/64811191/195835013-8f187266-96c7-4232-987e-d0ba92458d89.png)

![image](https://user-images.githubusercontent.com/64811191/195835036-300eb77d-d695-4096-8a9e-cdf8e20ff49b.png)